### PR TITLE
fix: rename monitoring table button from Challenge to View

### DIFF
--- a/components/PageMonitoring/MonitoringRow.tsx
+++ b/components/PageMonitoring/MonitoringRow.tsx
@@ -66,7 +66,7 @@ export default function MonitoringRow({ headers, position, tab }: Props) {
 					className="h-10"
 					onClick={() => navigate.push(`/monitoring/${position.position}${toQueryString(getCarryOnQueryParams(router))}`)}
 				>
-					{t("monitoring.challenge")}
+					{t("monitoring.view")}
 				</Button>
 			}
 			tab={tab}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -295,6 +295,7 @@
 		"no_active_positions": "There are no active positions.",
 		"force_sell": "Force Sell",
 		"challenge": "Challenge",
+		"view": "View",
 		"position_overview": "Position Overview",
 		"position": "Position",
 		"minted_total": "Minted Total",


### PR DESCRIPTION
## Summary
- Rename the action button in the monitoring table from "Challenge" to "View"
- Add new translation key `monitoring.view` to preserve the original "Challenge" label for actual challenge actions