### PR TITLE
[NO-TASK] Add frontendCode param to clone function call

### DIFF
--- a/components/PageMint/BorrowForm.tsx
+++ b/components/PageMint/BorrowForm.tsx
@@ -325,6 +325,7 @@ export default function PositionCreate({}) {
 					loanDetails.loanAmount,
 					toTimestamp(expirationDate),
 					BigInt(liquidationPrice),
+					frontendCode,
 				],
 				value: BigInt(collateralAmount),
 			});


### PR DESCRIPTION
## Summary
Adds the `frontendCode` parameter to the `clone` function call in `BorrowForm.tsx`.

## Problem
The `MintingHubGateway.clone()` function requires 7 parameters, but we were only passing 6. This caused "INTERNAL JSON-RPC ERROR" during transaction simulation.

## Solution
Added `frontendCode` as the 7th parameter, which:
- Fixes the clone transaction failure
- Enables proper referral tracking via `FrontendGateway`

## Changes
- `components/PageMint/BorrowForm.tsx`: Added `frontendCode` to clone args