### PR TITLE
[NO-TASK] Fix missing transaction toast translations

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -71,7 +71,9 @@
 			"price": "Preis:",
 			"receive": "Empfangen:",
 			"shares": "Anteile:",
-			"failed": "Transaktion fehlgeschlagen"
+			"failed": "Transaktion fehlgeschlagen",
+			"approving": "Genehmigung läuft...",
+			"approved": "Genehmigt"
 		},
 		"error": {
 			"insufficient_balance": "Nicht genügend {{symbol}} in deiner Wallet.",
@@ -271,7 +273,8 @@
 			"extending": "Position verlängern",
 			"extending_success": "Position erfolgreich verlängert",
 			"adjusting_price": "Positionspreis wird angepasst...",
-			"adjusting_price_success": "Positionspreis erfolgreich angepasst"
+			"adjusting_price_success": "Positionspreis erfolgreich angepasst",
+			"adjust_success": "Position erfolgreich angepasst"
 		}
 	},
 	"my_positions": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -71,7 +71,9 @@
 			"price": "Price:",
 			"receive": "Receive:",
 			"shares": "Shares:",
-			"failed": "Transaction Failed"
+			"failed": "Transaction Failed",
+			"approving": "Approving...",
+			"approved": "Approved"
 		},
 		"error": {
 			"insufficient_balance": "Not enough {{symbol}} in your wallet.",
@@ -271,7 +273,8 @@
 			"extending": "Extending position",
 			"extending_success": "Successfully extended position",
 			"adjusting_price": "Adjusting position price...",
-			"adjusting_price_success": "Position price adjusted successfully"
+			"adjusting_price_success": "Position price adjusted successfully",
+			"adjust_success": "Position adjusted successfully"
 		}
 	},
 	"my_positions": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -71,7 +71,9 @@
 			"price": "Precio:",
 			"receive": "Recibir:",
 			"shares": "Acciones:",
-			"failed": "Transacción fallida"
+			"failed": "Transacción fallida",
+			"approving": "Aprobando...",
+			"approved": "Aprobado"
 		},
 		"error": {
 			"insufficient_balance": "No hay suficientes {{symbol}} en su monedero.",
@@ -271,7 +273,8 @@
 			"extending": "Extendiendo posición",
 			"extending_success": "Posición extendida correctamente",
 			"adjusting_price": "Ajustando precio de posición...",
-			"adjusting_price_success": "Precio de posición ajustado exitosamente"
+			"adjusting_price_success": "Precio de posición ajustado exitosamente",
+			"adjust_success": "Posición ajustada exitosamente"
 		}
 	},
 	"my_positions": {

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -70,7 +70,10 @@
 			"collateral": "Garantie :",
 			"price": "Prix :",
 			"receive": "Recevoir :",
-			"shares": "Actions :"
+			"shares": "Actions :",
+			"failed": "Transaction échouée",
+			"approving": "Approbation en cours...",
+			"approved": "Approuvé"
 		},
 		"error": {
 			"insufficient_balance": "Solde insuffisant de {{symbol}} dans votre portefeuille.",
@@ -270,7 +273,8 @@
 			"extending": "Prolongation de la position",
 			"extending_success": "Position prolongée avec succès",
 			"adjusting_price": "Ajustement du prix de la position...",
-			"adjusting_price_success": "Prix de la position ajusté avec succès"
+			"adjusting_price_success": "Prix de la position ajusté avec succès",
+			"adjust_success": "Position ajustée avec succès"
 		}
 	},
 	"my_positions": {


### PR DESCRIPTION
## Summary
Adds missing i18n translation keys for transaction toasts that were displaying raw keys instead of translated text.

## Changes
- Added `common.txs.approving` and `common.txs.approved` keys (EN, ES, DE, FR)
- Added `mint.txs.adjust_success` key (EN, ES, DE, FR)
- Added missing `common.txs.failed` key (FR only)

## Issue
Toast notifications were showing `common.txs.approved` and `mint.txs.adjust_success` instead of proper translated text.