### PR TITLE
Add JUSD balance validation adjust loan

### DIFF
--- a/pages/mint/[address]/manage/loan.tsx
+++ b/pages/mint/[address]/manage/loan.tsx
@@ -21,6 +21,7 @@ export default function ManageLoan() {
 		liqPrice,
 		walletBalance,
 		jusdAllowance,
+		jusdBalance,
 		isInCooldown,
 		cooldownRemainingFormatted,
 		cooldownEndsAt,
@@ -60,6 +61,7 @@ export default function ManageLoan() {
 						currentPosition={currentPosition}
 						walletBalance={walletBalance}
 						jusdAllowance={jusdAllowance}
+						jusdBalance={jusdBalance}
 						refetchAllowance={refetch}
 						onSuccess={refetch}
 						onFullRepaySuccess={() => router.push("/dashboard")}


### PR DESCRIPTION
## Summary
- Add JUSD balance verification when repaying loans (partial or full)
- Show "Insufficient JUSD balance" error if user doesn't have enough funds
- Matches existing validation pattern used in Adjust Collateral

## Changes
- Pass `jusdBalance` prop to `AdjustLoan` component
- Add balance validation in repayment flow
- Disable repay button when insufficient balance

## Test plan
- [x] Attempt to repay loan with insufficient JUSD balance
- [x] Verify error message displays correctly
- [x] Verify button is disabled when balance insufficient
- [x] Verify successful repayment when balance is sufficient