### PR TITLE
Monitoring manage button url

### DIFF
--- a/pages/monitoring/[address]/index.tsx
+++ b/pages/monitoring/[address]/index.tsx
@@ -168,9 +168,7 @@ export default function PositionDetail() {
 							<Button
 								className="h-10 col-span-2 md:col-span-1 md:col-start-1 order-3 md:order-1"
 								onClick={() =>
-									navigate.push(
-										`/mint/${position.position}/manage${toQueryString(getCarryOnQueryParams(router))}`
-									)
+									navigate.push(`/mint/${position.position}/manage${toQueryString(getCarryOnQueryParams(router))}`)
 								}
 							>
 								{t("dashboard.manage")}


### PR DESCRIPTION
## Summary
Fixes the Manage button in the monitoring position detail page to navigate to the correct URL.

## Changes
- Changed navigation from `/mint/{address}/manage/collateral` to `/mint/{address}/manage`

## Problem
The Manage button was incorrectly navigating directly to the collateral sub-page instead of the main manage page, skipping the position management menu.

## Testing
1. Go to `/monitoring/{position-address}`
2. Click "Manage" button
3. Verify it navigates to `/mint/{position-address}/manage` (not `/manage/collateral`)