### PR TITLE
Navigate to Manage after loan adjustment

### DIFF
--- a/components/PageMint/AdjustLoan.tsx
+++ b/components/PageMint/AdjustLoan.tsx
@@ -207,7 +207,7 @@ export const AdjustLoan = ({
 				? onFullRepaySuccess
 				: () => {
 						setDeltaAmount("");
-						setStrategies({ [StrategyKey.ADD_COLLATERAL]: false, [StrategyKey.HIGHER_PRICE]: false });
+						setStrategies({ [StrategyKey.ADD_COLLATERAL]: false });
 						router.push(`/mint/${position.position}/manage`);
 				  },
 			setIsTxOnGoing,


### PR DESCRIPTION
## Changes
- Navigate to `/mint/{position}/manage` after successful loan adjustment (borrow more or partial repay)
- Add `useRouter` hook to `AdjustLoan` component for direct navigation
- Maintains `onFullRepaySuccess` callback for full repay scenarios
- Removed unused DefaultSummaryTable from component.

