### PR TITLE
Fixed incorrect bid amount display in Initiated Bids table.

### DIFF
--- a/components/PageMypositions/MyPositionsBidsRow.tsx
+++ b/components/PageMypositions/MyPositionsBidsRow.tsx
@@ -84,7 +84,7 @@ export default function MyPositionsBidsRow({ headers, bid, tab }: Props) {
 
 			{/* Bid */}
 			<div className="flex flex-col">
-				<div className="text-md ">{`${formatCurrency(formatUnits(bid.bid, 18), 2, 2)} ${TOKEN_SYMBOL}`}</div>
+				<div className="text-md ">{`${formatCurrency(formatUnits(bid.bid, 36), 2, 2)} ${TOKEN_SYMBOL}`}</div>
 			</div>
 
 			{/* State */}

--- a/components/PageMypositions/MyPositionsBidsTable.tsx
+++ b/components/PageMypositions/MyPositionsBidsTable.tsx
@@ -110,7 +110,7 @@ function sortBids(params: SortBids): BidsQueryItem[] {
 		// Bid Amount
 		bids.sort((a, b) => {
 			const calc = function (b: BidsQueryItem) {
-				return parseFloat(formatUnits(b.bid, 18));
+				return parseFloat(formatUnits(b.bid, 36));
 			};
 			return calc(b) - calc(a);
 		});


### PR DESCRIPTION
**Issue:** Bid amounts showed astronomically large numbers (e.g., 99 quintillion JUSD)

**Root cause:** `bid.bid` = `price × filledSize` which yields 36 decimals, but code used 18.

**Changes:**
- `MyPositionsBidsRow.tsx`: 18 → 36 decimals
- `MyPositionsBidsTable.tsx`: 18 → 36 decimals (sorting)