### PR TITLE
Fix MyPositions manage button to correct route

### DIFF
--- a/components/PageMypositions/MypositionsRow.tsx
+++ b/components/PageMypositions/MypositionsRow.tsx
@@ -134,7 +134,7 @@ export default function MypositionsRow({ headers, subHeaders, position, tab }: P
 			headers={headers}
 			subHeaders={subHeaders}
 			actionCol={
-				<Button className="h-10" onClick={() => navigate.push(`/mypositions/${position.position}/adjust`)}>
+				<Button className="h-10" onClick={() => navigate.push(`/mypositions/${position.position}/manage`)}>
 					Manage
 				</Button>
 			}


### PR DESCRIPTION
Fixed the "Manage" button in the Owned Positions table navigating to `/adjust` instead of `/manage`.