### PR TITLE
Fix 404 page logo and translations

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,16 +1,17 @@
 import Head from "next/head";
 import Link from "next/link";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useTranslation } from "next-i18next";
 import { SOCIAL, TOKEN_SYMBOL } from "@utils";
 
 export default function Custom404() {
+	const { t } = useTranslation();
 	return (
 		<main className="container-xl mx-auto">
 			<Head>
 				<title>{TOKEN_SYMBOL} - 404</title>
 			</Head>
 
-			{/* To load dynamic classes */}
 			<div className="hidden w-10 h-10" />
 			<div className="flex flex-col items-center justify-center w-full text-center" style={{ height: "60vh" }}>
 				<h1 className="text-right text-4xl font-bold">
@@ -18,7 +19,7 @@ export default function Custom404() {
 						<img src="/assets/JD-LOGO.svg" alt="logo" className="h-20" />
 					</picture>
 				</h1>
-				<h1 className="text-4xl font-bold mt-10">You seem to be in the wrong place</h1>
+				<h1 className="text-4xl font-bold mt-10">{t("common.404.title")}</h1>
 				<p className="text-2xl font-bold mt-4">
 					<Link
 						href={SOCIAL.Telegram}
@@ -26,7 +27,7 @@ export default function Custom404() {
 						target="_blank"
 						rel="noopener noreferrer"
 					>
-						Ping us on Telegram if you think this is a bug
+						{t("common.404.telegram_link")}
 					</Link>
 				</p>
 			</div>

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -1,5 +1,9 @@
 {
 	"common": {
+		"404": {
+			"title": "Du scheinst am falschen Ort zu sein",
+			"telegram_link": "Kontaktiere uns auf Telegram, wenn du denkst, dass dies ein Fehler ist"
+		},
 		"receive": "Empfangen",
 		"send": "Senden",
 		"approve": "Genehmigen",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,5 +1,9 @@
 {
 	"common": {
+		"404": {
+			"title": "You seem to be in the wrong place",
+			"telegram_link": "Ping us on Telegram if you think this is a bug"
+		},
 		"receive": "Receive",
 		"send": "Send",
 		"approve": "Approve",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,5 +1,9 @@
 {
 	"common": {
+		"404": {
+			"title": "Parece que estás en el lugar equivocado",
+			"telegram_link": "Contáctanos en Telegram si crees que esto es un error"
+		},
 		"receive": "Recibir",
 		"send": "Enviar",
 		"approve": "Aprobar",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,5 +1,9 @@
 {
 	"common": {
+		"404": {
+			"title": "Vous semblez être au mauvais endroit",
+			"telegram_link": "Contactez-nous sur Telegram si vous pensez que c'est un bug"
+		},
 		"receive": "Recevoir",
 		"send": "Envoyer",
 		"approve": "Approuver",


### PR DESCRIPTION
## Changes
- Fixed broken logo image (changed from `/assets/logo.svg` to `/assets/JD-LOGO.svg`)
- Added `getStaticProps` with `serverSideTranslations` to enable i18n on 404 page