### PR TITLE
Add CODEOWNERS for branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code Owners for JuiceDollar/bapp
+# These users must approve all pull requests to protected branches
+
+# Default owners for everything in the repo
+* @Danswar @TaprootFreak


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file requiring approval from @Danswar or @TaprootFreak for all changes
- This enables the branch protection rule for `main` branch

## Context
Branch protection rule has been configured on `main` with:
- Required approving reviews: 1
- Require review from Code Owners: enabled
- Dismiss stale reviews: enabled
- Force pushes: disabled
- Branch deletions: disabled