### PR TITLE
Fix prettierignore to exclude test artifacts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,7 @@
 build
 coverage
 .next
+
+# Test artifacts
+playwright-report
+test-results


### PR DESCRIPTION
## Summary
- Add `playwright-report` and `test-results` directories to `.prettierignore`
- Prevents local prettier checks from failing on generated test files

## Problem
Running `yarn lint:check` locally fails if test artifacts exist, even though they are already in `.gitignore`.

## Solution
Exclude test artifact directories from Prettier checks.