### PR TITLE
Improve visual test reliability for chart pages

### DIFF
--- a/tests/e2e/specs/visual.spec.ts
+++ b/tests/e2e/specs/visual.spec.ts
@@ -6,7 +6,8 @@ import { test, expect, Page } from "@playwright/test";
  */
 
 /**
- * Normalize scrollbars for consistent screenshot dimensions across platforms
+ * Normalize scrollbars for consistent screenshot dimensions across platforms.
+ * Must be called early (before waiting for content) to ensure consistent rendering.
  */
 async function normalizeScrollbars(page: Page): Promise<void> {
 	await page.addStyleTag({
@@ -24,11 +25,29 @@ async function normalizeScrollbars(page: Page): Promise<void> {
 	});
 }
 
+/**
+ * Wait for ApexCharts to fully render (including SVG path content).
+ * Used for pages with dynamic charts that load asynchronously.
+ */
+async function waitForCharts(page: Page): Promise<void> {
+	try {
+		await page.waitForSelector(".apexcharts-area-series path", { state: "visible", timeout: 20000 });
+		await page.waitForTimeout(1000);
+	} catch {
+		try {
+			await page.waitForSelector(".apexcharts-svg", { state: "visible", timeout: 10000 });
+			await page.waitForTimeout(1000);
+		} catch {
+			// Chart might not exist on this page
+		}
+	}
+}
+
 test.describe("Visual Regression", () => {
 	test("dashboard page", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("dashboard.png", {
 			fullPage: true,
@@ -38,8 +57,8 @@ test.describe("Visual Regression", () => {
 
 	test("mint page", async ({ page }) => {
 		await page.goto("/mint");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("mint.png", {
 			fullPage: true,
@@ -49,8 +68,9 @@ test.describe("Visual Regression", () => {
 
 	test("savings page", async ({ page }) => {
 		await page.goto("/savings");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
+		await waitForCharts(page);
 
 		await expect(page).toHaveScreenshot("savings.png", {
 			fullPage: true,
@@ -60,8 +80,9 @@ test.describe("Visual Regression", () => {
 
 	test("equity page", async ({ page }) => {
 		await page.goto("/equity");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
+		await waitForCharts(page);
 
 		await expect(page).toHaveScreenshot("equity.png", {
 			fullPage: true,
@@ -71,8 +92,8 @@ test.describe("Visual Regression", () => {
 
 	test("governance page", async ({ page }) => {
 		await page.goto("/governance");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("governance.png", {
 			fullPage: true,
@@ -82,8 +103,8 @@ test.describe("Visual Regression", () => {
 
 	test("challenges page", async ({ page }) => {
 		await page.goto("/challenges");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("challenges.png", {
 			fullPage: true,
@@ -93,8 +114,8 @@ test.describe("Visual Regression", () => {
 
 	test("swap page", async ({ page }) => {
 		await page.goto("/swap");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("swap.png", {
 			fullPage: true,
@@ -104,8 +125,8 @@ test.describe("Visual Regression", () => {
 
 	test("referrals page", async ({ page }) => {
 		await page.goto("/referrals");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("referrals.png", {
 			fullPage: true,
@@ -116,8 +137,8 @@ test.describe("Visual Regression", () => {
 	test("mobile viewport - dashboard", async ({ page }) => {
 		await page.setViewportSize({ width: 375, height: 667 });
 		await page.goto("/dashboard");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("dashboard-mobile.png", {
 			fullPage: true,
@@ -128,8 +149,8 @@ test.describe("Visual Regression", () => {
 	test("tablet viewport - dashboard", async ({ page }) => {
 		await page.setViewportSize({ width: 768, height: 1024 });
 		await page.goto("/dashboard");
-		await page.waitForLoadState("networkidle");
 		await normalizeScrollbars(page);
+		await page.waitForLoadState("networkidle");
 
 		await expect(page).toHaveScreenshot("dashboard-tablet.png", {
 			fullPage: true,


### PR DESCRIPTION
## Summary
- Add `waitForCharts()` function to explicitly wait for ApexCharts SVG rendering
- Apply chart waiting to savings and equity pages which use dynamic charts
- Reorder function calls: `normalizeScrollbars()` now runs before `waitForLoadState()` for consistent rendering

## Test plan
- [x] All 10 visual tests pass locally
- [ ] CI passes