### PR TITLE
Add loan amount column to monitoring table

### DIFF
--- a/components/PageMonitoring/MonitoringRow.tsx
+++ b/components/PageMonitoring/MonitoringRow.tsx
@@ -107,6 +107,13 @@ export default function MonitoringRow({ headers, position, tab }: Props) {
 				</div>
 			</div>
 
+			{/* Loan Amount */}
+			<div className="flex flex-col gap-2">
+				<div className={`col-span-2 text-md`}>
+					{formatCurrency(formatUnits(BigInt(position.principal), 18), 2, 2)} {TOKEN_SYMBOL}
+				</div>
+			</div>
+
 			{/* Expiration */}
 			<div className="flex flex-col gap-2">
 				<div className={`col-span-2 text-md ${maturity < 7 ? "text-text-warning font-bold" : ""}`}>

--- a/components/PageMonitoring/MonitoringTable.tsx
+++ b/components/PageMonitoring/MonitoringTable.tsx
@@ -18,6 +18,7 @@ export default function MonitoringTable() {
 		t("monitoring.collateral"),
 		t("dashboard.liquidation_price"),
 		t("monitoring.collateralization"),
+		t("my_positions.loan_amount"),
 		t("monitoring.expiration"),
 	];
 	const [tab, setTab] = useState<string>(headers[2]);
@@ -105,7 +106,12 @@ function sortPositions(
 			return calc(b) - calc(a);
 		});
 	} else if (tab === headers[3]) {
-		// sorft for Expiration
+		// sort for Loan Amount
+		list.sort((a, b) => {
+			return parseInt(b.principal) - parseInt(a.principal);
+		});
+	} else if (tab === headers[4]) {
+		// sort for Expiration
 		list.sort((a, b) => {
 			return b.expiration - a.expiration;
 		});


### PR DESCRIPTION
Adds a "Loan Amount" column to the monitoring table dashboard, positioned between "Collateralization" and "Expiration" columns.

Changes:
- Added loan amount header to MonitoringTable
- Added loan amount display in MonitoringRow using position.principal
- Added sorting logic for the new loan amount column
- Formats loan amount as JUSD currency

Close #81