### PR TITLE
fix: use single adjust() call for close position

### DIFF
--- a/components/PageMint/AdjustLoan.tsx
+++ b/components/PageMint/AdjustLoan.tsx
@@ -198,9 +198,7 @@ export const AdjustLoan = ({
 		handleLoanExecute({
 			outcome,
 			position,
-			userAddress: userAddress as Address,
 			principal,
-			collateralBalance,
 			isNativeWrappedPosition,
 			t,
 			onSuccess: isFullRepay

--- a/hooks/useExecuteLoanAdjust.tsx
+++ b/hooks/useExecuteLoanAdjust.tsx
@@ -12,9 +12,7 @@ import { SolverOutcome } from "../utils/positionSolver";
 interface ExecuteLoanAdjustParams {
 	outcome: SolverOutcome;
 	position: PositionQuery;
-	userAddress: Address;
 	principal: bigint;
-	collateralBalance: bigint;
 	isNativeWrappedPosition: boolean;
 	t: (key: string, params?: Record<string, string>) => string;
 	onSuccess: () => void;
@@ -23,75 +21,57 @@ interface ExecuteLoanAdjustParams {
 export const executeLoanAdjust = async ({
 	outcome,
 	position,
-	userAddress,
 	principal,
-	collateralBalance,
 	isNativeWrappedPosition,
 	t,
 	onSuccess,
 }: ExecuteLoanAdjustParams): Promise<void> => {
 	const posAddr = position.position as Address;
+	const depositAmount = outcome.deltaCollateral > 0n ? outcome.deltaCollateral : 0n;
+	const isWithdrawing = outcome.deltaCollateral < 0n;
+	const newPrincipal = outcome.next.debt === 0n ? 0n : principal + outcome.deltaDebt;
+	const LiqPrice = BigInt(position.price);
 
-	if (outcome.next.debt === 0n && principal > 0n) {
-		await executeTx({
-			contractParams: { address: posAddr, abi: PositionV2ABI, functionName: "repayFull", args: [] },
-			pendingTitle: t("mint.txs.pay_back", { symbol: position.stablecoinSymbol }),
-			successTitle: t("mint.txs.pay_back_success", { symbol: position.stablecoinSymbol }),
-		});
+	// Check if this is a full close (repay all debt and withdraw all collateral)
+	const isFullClose = outcome.next.debt === 0n && outcome.next.collateral === 0n && principal > 0n;
 
-		if (outcome.next.collateral === 0n && collateralBalance > 0n) {
-			await executeTx({
-				contractParams: {
-					address: posAddr,
-					abi: PositionV2ABI,
-					functionName: isNativeWrappedPosition ? "withdrawCollateralAsNative" : "withdrawCollateral",
-					args: [userAddress, collateralBalance],
-				},
-				pendingTitle: t("mint.txs.removing_collateral"),
-				successTitle: t("mint.txs.removing_collateral_success"),
-			});
-		}
-	} else {
-		const depositAmount = outcome.deltaCollateral > 0n ? outcome.deltaCollateral : 0n;
-		const isWithdrawing = outcome.deltaCollateral < 0n;
-		const newPrincipal = outcome.next.debt === 0n ? 0n : principal + outcome.deltaDebt;
-		const LiqPrice = BigInt(position.price);
+	const rows = [
+		outcome.deltaCollateral !== 0n && {
+			title: outcome.deltaCollateral > 0n ? t("mint.deposit_collateral") : t("mint.withdraw_collateral"),
+			value: formatPositionValue(
+				outcome.deltaCollateral > 0n ? outcome.deltaCollateral : -outcome.deltaCollateral,
+				position.collateralDecimals,
+				normalizeTokenSymbol(position.collateralSymbol)
+			),
+		},
+		outcome.deltaDebt !== 0n && {
+			title: outcome.deltaDebt > 0n ? t("mint.borrow_more") : t("mint.repay"),
+			value: formatPositionValue(outcome.deltaDebt > 0n ? outcome.deltaDebt : -outcome.deltaDebt, 18, position.stablecoinSymbol),
+		},
+	].filter(Boolean) as { title: string; value: string }[];
 
-		const rows = [
-			outcome.deltaCollateral !== 0n && {
-				title: outcome.deltaCollateral > 0n ? t("mint.deposit_collateral") : t("mint.withdraw_collateral"),
-				value: formatPositionValue(
-					outcome.deltaCollateral > 0n ? outcome.deltaCollateral : -outcome.deltaCollateral,
-					position.collateralDecimals,
-					normalizeTokenSymbol(position.collateralSymbol)
-				),
-			},
-			outcome.deltaDebt !== 0n && {
-				title: outcome.deltaDebt > 0n ? t("mint.borrow_more") : t("mint.repay"),
-				value: formatPositionValue(outcome.deltaDebt > 0n ? outcome.deltaDebt : -outcome.deltaDebt, 18, position.stablecoinSymbol),
-			},
-		].filter(Boolean) as { title: string; value: string }[];
+	const txTitle = isFullClose
+		? t("mint.close_position")
+		: outcome.deltaDebt < 0n
+		? `${t("mint.repay")} ${formatPositionValue(-outcome.deltaDebt, 18, position.stablecoinSymbol)}`
+		: outcome.deltaDebt > 0n
+		? `${t("mint.lending")} ${formatPositionValue(outcome.deltaDebt, 18, position.stablecoinSymbol)}`
+		: t("mint.adjust_position");
 
-		const txTitle =
-			outcome.deltaDebt < 0n
-				? `${t("mint.repay")} ${formatPositionValue(-outcome.deltaDebt, 18, position.stablecoinSymbol)}`
-				: outcome.deltaDebt > 0n
-				? `${t("mint.lending")} ${formatPositionValue(outcome.deltaDebt, 18, position.stablecoinSymbol)}`
-				: t("mint.adjust_position");
-
-		await executeTx({
-			contractParams: {
-				address: posAddr,
-				abi: PositionV2ABI,
-				functionName: "adjust",
-				args: [newPrincipal, outcome.next.collateral, LiqPrice, isWithdrawing && isNativeWrappedPosition],
-				value: isNativeWrappedPosition && depositAmount > 0n ? depositAmount : undefined,
-			},
-			pendingTitle: txTitle,
-			successTitle: txTitle,
-			rows,
-		});
-	}
+	// Use single adjust() call for all operations including full close
+	// The adjust() function handles: repay debt, withdraw collateral, and price changes in one transaction
+	await executeTx({
+		contractParams: {
+			address: posAddr,
+			abi: PositionV2ABI,
+			functionName: "adjust",
+			args: [newPrincipal, outcome.next.collateral, LiqPrice, isWithdrawing && isNativeWrappedPosition],
+			value: isNativeWrappedPosition && depositAmount > 0n ? depositAmount : undefined,
+		},
+		pendingTitle: txTitle,
+		successTitle: txTitle,
+		rows,
+	});
 
 	store.dispatch(fetchPositionsList());
 	onSuccess();


### PR DESCRIPTION
## Summary

This PR optimizes the position close flow by replacing two separate blockchain transactions with a single `adjust()` call.

## Problem

Previously, closing a loan position required **two separate blockchain transactions**:

1. **Transaction 1:** `repayFull()` - Repays the entire debt
2. **Transaction 2:** `withdrawCollateral()` - Withdraws all collateral back to the user

This approach had several drawbacks:
- **Higher gas costs:** Users paid gas fees for two transactions instead of one
- **Poor UX:** Users had to confirm two MetaMask popups and wait for two transactions to complete
- **Unnecessary complexity:** The code had special-case handling for full close vs. partial adjustments

## Solution

The smart contract's `adjust()` function already supports all necessary operations in a single call:
- Repaying debt (when `newPrincipal < principal`)
- Withdrawing collateral (when `newCollateral < currentCollateral`)
- Adjusting liquidation price

By calling `adjust(0, 0, price, withdrawAsNative)` for a full close, we achieve the same result with:
- ✅ **One transaction** instead of two
- ✅ **Lower gas costs** for users
- ✅ **Single MetaMask confirmation**
- ✅ **Simpler, more maintainable code**

## Code Changes

### `hooks/useExecuteLoanAdjust.tsx`

**Before:**
```typescript
if (outcome.next.debt === 0n && principal > 0n) {
    // First transaction: repay debt
    await executeTx({
        functionName: "repayFull",
        // ...
    });
    
    // Second transaction: withdraw collateral
    if (outcome.next.collateral === 0n && collateralBalance > 0n) {
        await executeTx({
            functionName: "withdrawCollateral",
            // ...
        });
    }
} else {
    // Regular adjust for partial changes
    await executeTx({ functionName: "adjust", ... });
}
```

**After:**
```typescript
// Single adjust() call handles ALL operations:
// - Full close (repay + withdraw)
// - Partial repay
// - Borrow more
// - Collateral changes
await executeTx({
    functionName: "adjust",
    args: [newPrincipal, outcome.next.collateral, LiqPrice, isWithdrawing && isNativeWrappedPosition],
    // ...
});
```

### `components/PageMint/AdjustLoan.tsx`

- Removed `userAddress` and `collateralBalance` parameters from `handleLoanExecute()` call (no longer needed)

## Test Plan

- [ ] Create a new loan position with cBTC collateral
- [ ] Close the position completely
- [ ] Verify only **ONE** MetaMask confirmation is required
- [ ] Verify collateral is returned correctly to wallet
- [ ] Test with native wrapped positions (cBTC → BTC)
- [ ] Test partial repayment (should still work via adjust)
- [ ] Test borrowing more (should still work via adjust)

## Related

Based on #91 - this PR contains only the production code changes without the E2E tests.