### PR TITLE
Use position properties for collateral display in mint toast

### DIFF
--- a/components/PageMint/BorrowForm.tsx
+++ b/components/PageMint/BorrowForm.tsx
@@ -22,6 +22,7 @@ import {
 	toTimestamp,
 	NATIVE_WRAPPED_SYMBOLS,
 	normalizeTokenSymbol,
+	formatPositionValue,
 } from "@utils";
 import { TokenBalance, useWalletERC20Balances } from "../../hooks/useWalletBalances";
 import { RootState, store } from "../../redux/redux.store";
@@ -328,7 +329,11 @@ export default function PositionCreate({}) {
 				},
 				{
 					title: t("common.txs.collateral"),
-					value: formatBigInt(BigInt(collateralAmount), 18, 4) + " cBTC",
+					value: formatPositionValue(
+						BigInt(collateralAmount),
+						selectedPosition.collateralDecimals,
+						normalizeTokenSymbol(selectedPosition.collateralSymbol)
+					),
 				},
 				{
 					title: t("common.txs.transaction"),


### PR DESCRIPTION
Close #96

Replaces hardcoded `18` decimals and `"cBTC"` symbol in the minting toast with `selectedPosition.collateralDecimals` and `normalizeTokenSymbol(selectedPosition.collateralSymbol)`. 
Also switches to `formatPositionValue` for consistent formatting across the codebase.