### PR TITLE
Add 2% voting power guard for base rate buttons

### DIFF
--- a/components/Guards/GuardToMinVotingPower.tsx
+++ b/components/Guards/GuardToMinVotingPower.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Tooltip } from "flowbite-react";
+import { useGovStats } from "@hooks";
+import Button from "@components/Button";
+
+interface Props {
+	children?: React.ReactNode;
+	label?: string;
+	buttonClassName?: string;
+}
+
+const MIN_VOTING_POWER_BPS = 200n;
+
+export default function GuardToMinVotingPower(props: Props) {
+	const { totalVotes, userVotes } = useGovStats();
+	const hasEnoughVotingPower = totalVotes > 0n && (userVotes * 10000n) / totalVotes >= MIN_VOTING_POWER_BPS;
+
+	if (!hasEnoughVotingPower) {
+		return (
+			<Tooltip content="You need at least 2% voting power to perform this action." style="light">
+				<Button className={`h-10 ${props.buttonClassName ?? ""}`} disabled>
+					{props.label ?? "Action"}
+				</Button>
+			</Tooltip>
+		);
+	}
+
+	return <>{props.children}</>;
+}

--- a/components/PageGovernance/GovernanceLeadrateCurrent.tsx
+++ b/components/PageGovernance/GovernanceLeadrateCurrent.tsx
@@ -4,6 +4,7 @@ import { formatCurrency, shortenAddress } from "../../utils/format";
 import { useDelegationQuery } from "@hooks";
 import { AddressLabelSimple } from "@components/AddressLabel";
 import GuardToAllowedChainBtn from "@components/Guards/GuardToAllowedChainBtn";
+import GuardToMinVotingPower from "@components/Guards/GuardToMinVotingPower";
 import Button from "@components/Button";
 import NormalInput from "@components/Input/NormalInput";
 import AppCard from "@components/AppCard";
@@ -119,14 +120,16 @@ export default function GovernanceLeadrateCurrent({}: Props) {
 					label={t("dashboard.propose")}
 					disabled={isDisabled || isHidden}
 				>
-					<Button
-						className="h-full full sm:max-w-48 p-4"
-						disabled={isDisabled || isHidden}
-						isLoading={isHandling}
-						onClick={(e) => handleOnClick(e)}
-					>
-						{t("dashboard.propose")}
-					</Button>
+					<GuardToMinVotingPower buttonClassName="h-full w-full sm:max-w-48 p-4" label={t("dashboard.propose")}>
+						<Button
+							className="h-full full sm:max-w-48 p-4"
+							disabled={isDisabled || isHidden}
+							isLoading={isHandling}
+							onClick={(e) => handleOnClick(e)}
+						>
+							{t("dashboard.propose")}
+						</Button>
+					</GuardToMinVotingPower>
 				</GuardToAllowedChainBtn>
 			</div>
 		</AppCard>

--- a/components/PageGovernance/GovernanceLeadrateRow.tsx
+++ b/components/PageGovernance/GovernanceLeadrateRow.tsx
@@ -10,6 +10,7 @@ import { ADDRESS, SavingsABI } from "@juicedollar/jusd";
 import { ApiLeadrateInfo, LeadrateProposed } from "@juicedollar/api";
 import Button from "@components/Button";
 import GuardToAllowedChainBtn from "@components/Guards/GuardToAllowedChainBtn";
+import GuardToMinVotingPower from "@components/Guards/GuardToMinVotingPower";
 import { toast } from "react-toastify";
 import { renderErrorTxToast, TxToast } from "@components/TxToast";
 import { mainnet, testnet } from "@config";
@@ -138,25 +139,29 @@ export default function GovernanceLeadrateRow({ headers, info, proposal, current
 					currentProposal ? (
 						info.isPending && info.isProposal ? (
 							<GuardToAllowedChainBtn label="Deny" disabled={!info.isPending || !info.isProposal}>
-								<Button
-									className="h-10"
-									disabled={!info.isPending || !info.isProposal || isHidden}
-									isLoading={isDenying}
-									onClick={(e) => handleOnDeny(e)}
-								>
-									Deny
-								</Button>
+								<GuardToMinVotingPower label="Deny">
+									<Button
+										className="h-10"
+										disabled={!info.isPending || !info.isProposal || isHidden}
+										isLoading={isDenying}
+										onClick={(e) => handleOnDeny(e)}
+									>
+										Deny
+									</Button>
+								</GuardToMinVotingPower>
 							</GuardToAllowedChainBtn>
 						) : (
 							<GuardToAllowedChainBtn label="Apply" disabled={!info.isProposal}>
-								<Button
-									className="h-10"
-									disabled={!info.isProposal || isHidden}
-									isLoading={isApplying}
-									onClick={(e) => handleOnApply(e)}
-								>
-									Apply
-								</Button>
+								<GuardToMinVotingPower label="Apply">
+									<Button
+										className="h-10"
+										disabled={!info.isProposal || isHidden}
+										isLoading={isApplying}
+										onClick={(e) => handleOnApply(e)}
+									>
+										Apply
+									</Button>
+								</GuardToMinVotingPower>
 							</GuardToAllowedChainBtn>
 						)
 					) : (


### PR DESCRIPTION
## Summary
- New `GuardToMinVotingPower` component checks if user has ≥ 2% voting power
- Wraps Propose (GovernanceLeadrateCurrent), Apply/Deny (GovernanceLeadrateRow) buttons
- Shows disabled button with tooltip when voting power insufficient

## Details
- Uses `useGovStats()` for `totalVotes` and `userVotes`
- BigInt-safe: `(userVotes * 10000n) / totalVotes >= 200n`
- Guard nesting: `GuardToAllowedChainBtn` wraps `GuardToMinVotingPower` (disconnected users see "connect wallet" first)

following the same implementation of:
https://github.com/d-EURO/dapp/pull/284
https://github.com/d-EURO/dapp/pull/286