### PR TITLE
UI improvements in multiple components

### DIFF
--- a/components/PageChallenges/ChallengesRow.tsx
+++ b/components/PageChallenges/ChallengesRow.tsx
@@ -82,29 +82,29 @@ export default function ChallengesRow({ headers, challenge, tab }: Props) {
 			}
 			tab={tab}
 			showFirstHeader
+			mobileFirstColumnSplit
 		>
 			{/* Collateral */}
 			<div className="flex flex-col">
 				{/* desktop view */}
 				<div className="max-md:hidden flex flex-row items-center">
 					<span className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={8} />
 					</span>
-					<span className={`col-span-2 text-md font-extrabold text-text-primary`}>{`${formatCurrency(
+					<span className="text-md font-extrabold text-text-primary">{`${formatCurrency(
 						challengeRemainingSize,
 						...availableFractionDigits
 					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
-
-				{/* mobile view */}
-				<div className="md:hidden flex flex-row items-center py-1 mb-3">
-					<div className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
-					</div>
-					<div className={`col-span-2 text-md text-text-primary font-semibold`}>{`${formatCurrency(
+				{/* mobile view*/}
+				<div className="md:hidden flex flex-row items-center justify-end gap-1.5">
+					<span className="shrink-0 cursor-pointer" onClick={openExplorer}>
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={5} />
+					</span>
+					<span className="text-md text-text-primary font-semibold">{`${formatCurrency(
 						challengeRemainingSize,
 						...availableFractionDigits
-					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</div>
+					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
 			</div>
 

--- a/components/PageDashboard/MyBorrow.tsx
+++ b/components/PageDashboard/MyBorrow.tsx
@@ -91,7 +91,7 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 									<div className="flex items-center justify-center">
 										<TokenLogo currency={item.symbol} size={5} />
 									</div>
-									<div className="font-medium text-base leading-tight">
+									<div className="font-medium text-sm leading-tight">
 										{item.collateralAmount} {item.symbol}
 									</div>
 								</div>
@@ -101,7 +101,7 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 								<div className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
 									{t("dashboard.liquidation_price")}
 								</div>
-								<div className="font-medium text-base leading-tight">
+								<div className="font-medium text-sm leading-tight">
 									{item.liquidationPrice} {TOKEN_SYMBOL}
 								</div>
 							</div>
@@ -110,12 +110,12 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 								<div className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
 									{t("dashboard.collateralization")}
 								</div>
-								<div className="font-medium text-base leading-tight">{item.collateralization} %</div>
+								<div className="font-medium text-sm leading-tight">{item.collateralization} %</div>
 							</div>
 
 							<div className="w-full flex flex-row justify-between items-center">
 								<div className="text-text-muted2 text-xs font-medium leading-[1.125rem]">{t("dashboard.loan_due_in")}</div>
-								<div className="font-medium text-base leading-tight">
+								<div className="font-medium text-sm leading-tight">
 									{item.loanDueIn} {t("common.days")}
 								</div>
 							</div>
@@ -124,7 +124,7 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 								<div className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
 									{t("dashboard.amount_borrowed")}
 								</div>
-								<div className="font-extrabold text-base leading-tight">
+								<div className="font-extrabold text-sm leading-tight">
 									{item.amountBorrowed} {TOKEN_SYMBOL}
 								</div>
 							</div>

--- a/components/PageDashboard/MyBorrow.tsx
+++ b/components/PageDashboard/MyBorrow.tsx
@@ -136,7 +136,9 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 					))}
 				</>
 			) : (
-				<NoDataRow className="col-span-5">{t("dashboard.no_borrowings_yet")}</NoDataRow>
+				<div className="w-full py-[1.125rem] mb-1.5 flex items-center justify-center">
+					<span className="text-text-muted2 text-base font-[350] leading-tight">{t("dashboard.no_borrowings_yet")}</span>
+				</div>
 			)}
 		</div>
 	);

--- a/components/PageDashboard/MyBorrow.tsx
+++ b/components/PageDashboard/MyBorrow.tsx
@@ -85,11 +85,11 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 				<>
 					{borrowData.map((item) => (
 						<div className="w-full flex flex-col gap-1 border-b border-borders-dividerLight" key={item.position}>
-							<div className="mb-2 w-full flex flex-col justify-start items-start gap-1">
+							<div className="mb-2 w-full flex flex-row justify-between items-center">
 								<div className="text-text-muted2 text-xs font-medium leading-[1.125rem]">{t("dashboard.collateral")}</div>
-								<div className="flex flex-row items-center gap-2">
+								<div className="flex flex-row items-center gap-1.5">
 									<div className="flex items-center justify-center">
-										<TokenLogo currency={item.symbol} size={8} />
+										<TokenLogo currency={item.symbol} size={5} />
 									</div>
 									<div className="font-medium text-base leading-tight">
 										{item.collateralAmount} {item.symbol}

--- a/components/PageDashboard/MyBorrow.tsx
+++ b/components/PageDashboard/MyBorrow.tsx
@@ -85,7 +85,7 @@ const MobileTable = ({ borrowData }: { borrowData: BorrowData[] }) => {
 				<>
 					{borrowData.map((item) => (
 						<div className="w-full flex flex-col gap-1 border-b border-borders-dividerLight" key={item.position}>
-							<div className="mb-2 w-full flex flex-row justify-between items-center">
+							<div className="w-full flex flex-row justify-between items-center">
 								<div className="text-text-muted2 text-xs font-medium leading-[1.125rem]">{t("dashboard.collateral")}</div>
 								<div className="flex flex-row items-center gap-1.5">
 									<div className="flex items-center justify-center">

--- a/components/PageDashboard/MyEquity.tsx
+++ b/components/PageDashboard/MyEquity.tsx
@@ -2,37 +2,12 @@ import TokenLogo from "@components/TokenLogo";
 import { useTranslation } from "next-i18next";
 import { HeaderCell, LinkTitle, NoDataRow } from "./SectionTable";
 import { useWalletERC20Balances } from "../../hooks/useWalletBalances";
-import { formatCurrency, POOL_SHARE_TOKEN_SYMBOL } from "@utils";
+import { formatCurrency, POOL_SHARE_TOKEN_SYMBOL, TOKEN_SYMBOL } from "@utils";
 import { ADDRESS, EquityABI } from "@juicedollar/jusd";
 import { useChainId, useReadContract } from "wagmi";
 import { formatUnits } from "viem";
 import { useRouter } from "next/router";
 import { getPublicViewAddress } from "../../utils/url";
-import { TOKEN_SYMBOL } from "@utils";
-
-const EquityRow = ({
-	symbol,
-	currentInvestment = "0.00",
-	amount = "0.00",
-}: {
-	symbol: string;
-	currentInvestment: string;
-	amount: string;
-}) => {
-	return (
-		<>
-			<div className="flex items-center py-1.5">
-				<span className="flex items-center pr-3">
-					<TokenLogo currency={symbol} size={8} />
-				</span>
-			</div>
-			<span className="flex items-center text-text-primary text-base font-medium leading-[1.25rem]">
-				{currentInvestment} {symbol}
-			</span>
-			<span className="flex items-center justify-end text-text-primary text-base font-extrabold leading-[1.25rem]">{amount}</span>
-		</>
-	);
-};
 
 export const MyEquity = () => {
 	const { t } = useTranslation();
@@ -41,13 +16,7 @@ export const MyEquity = () => {
 	const overwrite = getPublicViewAddress(router);
 
 	const { balancesByAddress } = useWalletERC20Balances(
-		[
-			{
-				name: POOL_SHARE_TOKEN_SYMBOL,
-				symbol: POOL_SHARE_TOKEN_SYMBOL,
-				address: ADDRESS[chainId].equity,
-			},
-		],
+		[{ name: POOL_SHARE_TOKEN_SYMBOL, symbol: POOL_SHARE_TOKEN_SYMBOL, address: ADDRESS[chainId].equity }],
 		{ accountAddress: overwrite as `0x${string}` }
 	);
 
@@ -58,50 +27,72 @@ export const MyEquity = () => {
 		args: [balancesByAddress[ADDRESS[chainId].equity]?.balanceOf || 0n],
 	});
 
-	const equityData = [
-		{
-			symbol: POOL_SHARE_TOKEN_SYMBOL,
-			currentInvestment: formatCurrency(formatUnits(balancesByAddress[ADDRESS[chainId].equity]?.balanceOf || 0n, 18), 2, 2) as string,
-			amount: formatCurrency(formatUnits(deuroNative, 18), 2, 2) as string,
-		},
-	];
-
-	const totalInvested = deuroNative;
-	const isEquityData = totalInvested > 0;
+	const hasData = deuroNative > 0n;
+	const investmentFmt = formatCurrency(formatUnits(balancesByAddress[ADDRESS[chainId].equity]?.balanceOf || 0n, 18), 2, 2) as string;
+	const amountFmt = formatCurrency(formatUnits(deuroNative, 18), 2, 2) as string;
 
 	return (
 		<div className="w-full h-full p-4 sm:p-8 flex flex-col items-start">
-			<LinkTitle href={"/equity"}>{t("dashboard.my_equity")}</LinkTitle>
-			<div className="w-full flex flex-row justify-between items-center">
-				<div
-					className={`w-full grid grid-rows-[auto_auto] ${
-						isEquityData ? "grid-cols-[auto_1fr_auto]" : "grid-cols-1 sm:grid-cols-[auto_1fr_auto]"
-					}`}
-				>
-					{/** Headers */}
-					<span className={isEquityData ? "" : "hidden sm:block"}></span>
-					<HeaderCell className={isEquityData ? "" : "hidden sm:block"}>{t("dashboard.current_investment")}</HeaderCell>
-					<HeaderCell className={isEquityData ? "text-right" : "hidden sm:block text-right"}>
-						{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}
-					</HeaderCell>
-					{isEquityData ? (
-						equityData.map((item) => <EquityRow key={item.symbol} {...item} />)
-					) : (
-						<NoDataRow className="col-span-1 sm:col-span-2 text-center justify-self-center">
-							{t("dashboard.no_investments_yet")}
-						</NoDataRow>
-					)}
-				</div>
+			<LinkTitle href="/equity">{t("dashboard.my_equity")}</LinkTitle>
+
+			{/* Desktop table */}
+			<div className="hidden sm:grid w-full grid-cols-[auto_1fr_auto] grid-rows-[auto_auto]">
+				<span />
+				<HeaderCell>{t("dashboard.current_investment")}</HeaderCell>
+				<HeaderCell className="text-right">{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}</HeaderCell>
+				{hasData ? (
+					<>
+						<div className="flex items-center py-1.5 pr-3">
+							<TokenLogo currency={POOL_SHARE_TOKEN_SYMBOL} size={8} />
+						</div>
+						<span className="flex items-center text-text-primary text-base font-medium leading-[1.25rem]">
+							{investmentFmt} {POOL_SHARE_TOKEN_SYMBOL}
+						</span>
+						<span className="flex items-center justify-end text-text-primary text-base font-extrabold leading-[1.25rem]">
+							{amountFmt}
+						</span>
+					</>
+				) : (
+					<NoDataRow className="col-span-2">{t("dashboard.no_investments_yet")}</NoDataRow>
+				)}
 			</div>
-			{isEquityData && (
+
+			{/* Mobile stacked rows */}
+			<div className="sm:hidden w-full flex flex-col gap-3">
+				{hasData ? (
+					<>
+						<div className="w-full flex flex-row justify-between items-center gap-2">
+							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
+								{t("dashboard.current_investment")}
+							</span>
+							<div className="flex flex-row items-center gap-1.5 shrink-0">
+								<TokenLogo currency={POOL_SHARE_TOKEN_SYMBOL} size={5} />
+								<span className="text-text-primary text-base font-medium leading-tight">
+									{investmentFmt} {POOL_SHARE_TOKEN_SYMBOL}
+								</span>
+							</div>
+						</div>
+						<div className="w-full flex flex-row justify-between items-center gap-2">
+							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
+								{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}
+							</span>
+							<span className="text-text-primary text-base font-extrabold leading-tight shrink-0">{amountFmt}</span>
+						</div>
+					</>
+				) : (
+					<div className="w-full py-[1.125rem] flex items-center justify-center">
+						<span className="text-text-muted2 text-base font-[350] leading-tight">{t("dashboard.no_investments_yet")}</span>
+					</div>
+				)}
+			</div>
+
+			{hasData && (
 				<div className="w-full pt-5 flex-1 flex items-end">
 					<div className="flex flex-row justify-between items-center w-full">
 						<span className="text-text-primary text-base font-extrabold leading-[1.25rem]">
 							{t("dashboard.total_invested")}
 						</span>
-						<span className="text-text-primary text-base font-extrabold leading-[1.25rem]">
-							{formatCurrency(formatUnits(totalInvested, 18), 2, 2) as string}
-						</span>
+						<span className="text-text-primary text-base font-extrabold leading-[1.25rem]">{amountFmt}</span>
 					</div>
 				</div>
 			)}

--- a/components/PageDashboard/MyEquity.tsx
+++ b/components/PageDashboard/MyEquity.tsx
@@ -67,7 +67,7 @@ export const MyEquity = () => {
 							</span>
 							<div className="flex flex-row items-center gap-1.5 shrink-0">
 								<TokenLogo currency={POOL_SHARE_TOKEN_SYMBOL} size={5} />
-								<span className="text-text-primary text-base font-medium leading-tight">
+								<span className="text-text-primary text-sm font-medium leading-tight">
 									{investmentFmt} {POOL_SHARE_TOKEN_SYMBOL}
 								</span>
 							</div>
@@ -76,7 +76,7 @@ export const MyEquity = () => {
 							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
 								{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}
 							</span>
-							<span className="text-text-primary text-base font-extrabold leading-tight shrink-0">{amountFmt}</span>
+							<span className="text-text-primary text-sm font-extrabold leading-tight shrink-0">{amountFmt}</span>
 						</div>
 					</>
 				) : (

--- a/components/PageDashboard/MyEquity.tsx
+++ b/components/PageDashboard/MyEquity.tsx
@@ -73,11 +73,17 @@ export const MyEquity = () => {
 		<div className="w-full h-full p-4 sm:p-8 flex flex-col items-start">
 			<LinkTitle href={"/equity"}>{t("dashboard.my_equity")}</LinkTitle>
 			<div className="w-full flex flex-row justify-between items-center">
-				<div className="w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] grid-rows-[auto_auto]">
+				<div
+					className={`w-full grid grid-rows-[auto_auto] ${
+						isEquityData ? "grid-cols-[auto_1fr_auto]" : "grid-cols-1 sm:grid-cols-[auto_1fr_auto]"
+					}`}
+				>
 					{/** Headers */}
-					<span className="hidden sm:block"></span>
-					<HeaderCell className="hidden sm:block">{t("dashboard.current_investment")}</HeaderCell>
-					<HeaderCell className="hidden sm:block text-right">{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}</HeaderCell>
+					<span className={isEquityData ? "" : "hidden sm:block"}></span>
+					<HeaderCell className={isEquityData ? "" : "hidden sm:block"}>{t("dashboard.current_investment")}</HeaderCell>
+					<HeaderCell className={isEquityData ? "text-right" : "hidden sm:block text-right"}>
+						{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}
+					</HeaderCell>
 					{isEquityData ? (
 						equityData.map((item) => <EquityRow key={item.symbol} {...item} />)
 					) : (

--- a/components/PageDashboard/MyEquity.tsx
+++ b/components/PageDashboard/MyEquity.tsx
@@ -73,15 +73,17 @@ export const MyEquity = () => {
 		<div className="w-full h-full p-4 sm:p-8 flex flex-col items-start">
 			<LinkTitle href={"/equity"}>{t("dashboard.my_equity")}</LinkTitle>
 			<div className="w-full flex flex-row justify-between items-center">
-				<div className="w-full grid grid-cols-[auto_1fr_auto] grid-rows-[auto_auto]">
+				<div className="w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_auto] grid-rows-[auto_auto]">
 					{/** Headers */}
-					<span></span>
-					<HeaderCell>{t("dashboard.current_investment")}</HeaderCell>
-					<HeaderCell className="text-right">{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}</HeaderCell>
+					<span className="hidden sm:block"></span>
+					<HeaderCell className="hidden sm:block">{t("dashboard.current_investment")}</HeaderCell>
+					<HeaderCell className="hidden sm:block text-right">{t("dashboard.symbol_amount", { symbol: TOKEN_SYMBOL })}</HeaderCell>
 					{isEquityData ? (
 						equityData.map((item) => <EquityRow key={item.symbol} {...item} />)
 					) : (
-						<NoDataRow className="col-span-2">{t("dashboard.no_investments_yet")}</NoDataRow>
+						<NoDataRow className="col-span-1 sm:col-span-2 text-center justify-self-center">
+							{t("dashboard.no_investments_yet")}
+						</NoDataRow>
 					)}
 				</div>
 			</div>

--- a/components/PageDashboard/MySavings.tsx
+++ b/components/PageDashboard/MySavings.tsx
@@ -53,18 +53,18 @@ export const MySavings = () => {
 							</span>
 							<div className="flex flex-row items-center gap-1.5 shrink-0">
 								<TokenLogo currency={TOKEN_SYMBOL} size={5} />
-								<span className="text-text-primary text-base font-extrabold leading-tight">{balanceFmt}</span>
+								<span className="text-text-primary text-sm font-extrabold leading-tight">{balanceFmt}</span>
 							</div>
 						</div>
 						<div className="w-full flex flex-row justify-between items-center gap-2">
 							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem]">{t("dashboard.total_earned")}</span>
-							<span className="text-text-primary text-base font-medium leading-tight">{earnedFmt}</span>
+							<span className="text-text-primary text-sm font-medium leading-tight">{earnedFmt}</span>
 						</div>
 						<div className="w-full flex flex-row justify-between items-center gap-2">
 							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem] min-w-0 flex-1">
 								{t("dashboard.interest_to_be_collected")}
 							</span>
-							<span className="text-text-primary text-base font-medium leading-tight shrink-0">{interestFmt}</span>
+							<span className="text-text-primary text-sm font-medium leading-tight shrink-0">{interestFmt}</span>
 						</div>
 					</>
 				) : (
@@ -75,9 +75,9 @@ export const MySavings = () => {
 			</div>
 
 			{hasData && (
-				<div className="w-full flex-1 pt-10 flex flex-col sm:flex-row items-stretch sm:items-end gap-4">
+				<div className="w-full flex-1 pt-10 flex flex-row items-stretch justify-center gap-2 sm:gap-4">
 					<Button
-						className="w-full h-10"
+						className="flex-1 min-w-0 h-9 px-2 text-sm sm:h-10 sm:px-4 sm:text-base"
 						disabled={interestToBeCollected === 0n}
 						isLoading={isReinvesting}
 						onClick={handleReinvest}
@@ -86,7 +86,7 @@ export const MySavings = () => {
 						{t("dashboard.reinvest")}
 					</Button>
 					<SecondaryButton
-						className="w-full h-10"
+						className="flex-1 min-w-0 h-9 px-2 text-sm sm:h-10 sm:px-4 sm:text-base"
 						disabled={interestToBeCollected === 0n}
 						isLoading={isClaiming}
 						onClick={claimInterest}

--- a/components/PageDashboard/MySavings.tsx
+++ b/components/PageDashboard/MySavings.tsx
@@ -9,68 +9,73 @@ import Image from "next/image";
 import { faRotateRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-const SavingsRow = ({
-	balance,
-	totalEarnedInterest,
-	interestToBeCollected,
-}: {
-	balance: bigint;
-	totalEarnedInterest: bigint;
-	interestToBeCollected: bigint;
-}) => {
-	return (
-		<>
-			<div className="pr-3 flex items-center">
-				<TokenLogo currency={TOKEN_SYMBOL} size={8} />
-			</div>
-			<span className="flex items-center text-text-primary text-base font-extrabold">
-				{formatCurrency(formatUnits(balance, 18), 2, 2)}
-			</span>
-			<span className="flex items-center text-text-primary text-base font-medium">
-				{formatCurrency(formatUnits(totalEarnedInterest, 18), 2, 2)}
-			</span>
-			<span className="flex items-center text-text-primary text-base font-medium">
-				{formatCurrency(formatUnits(interestToBeCollected, 18), 2, 2)}
-			</span>
-		</>
-	);
-};
-
 export const MySavings = () => {
 	const { userSavingsBalance, totalEarnedInterest, interestToBeCollected, isReinvesting, isClaiming, claimInterest, handleReinvest } =
 		useSavingsInterest();
 	const { t } = useTranslation();
 
-	const savingsData = userSavingsBalance > 0n || totalEarnedInterest > 0n || interestToBeCollected > 0n;
+	const hasData = userSavingsBalance > 0n || totalEarnedInterest > 0n || interestToBeCollected > 0n;
+	const balanceFmt = formatCurrency(formatUnits(userSavingsBalance, 18), 2, 2) as string;
+	const earnedFmt = formatCurrency(formatUnits(totalEarnedInterest, 18), 2, 2) as string;
+	const interestFmt = formatCurrency(formatUnits(interestToBeCollected, 18), 2, 2) as string;
 
 	return (
 		<div className="w-full h-full p-4 sm:p-8 flex flex-col items-start">
-			<LinkTitle href={"/savings"}>{t("dashboard.my_savings")}</LinkTitle>
-			<div className="w-full flex flex-row justify-between items-center">
-				<div
-					className={`w-full grid grid-rows-[auto_auto] gap-y-1 ${
-						savingsData ? "grid-cols-[auto_1fr_1fr_1fr]" : "grid-cols-1 sm:grid-cols-[auto_1fr_1fr_1fr]"
-					}`}
-				>
-					<span className={`${savingsData ? "w-11 pr-3" : "hidden sm:block w-11 pr-3"}`}></span>
-					<HeaderCell className={savingsData ? "" : "hidden sm:block"}>{t("dashboard.current_investment")}</HeaderCell>
-					<HeaderCell className={savingsData ? "" : "hidden sm:block"}>{t("dashboard.total_earned")}</HeaderCell>
-					<HeaderCell className={savingsData ? "" : "hidden sm:block"}>{t("dashboard.interest_to_be_collected")}</HeaderCell>
-					{savingsData ? (
-						<SavingsRow
-							balance={userSavingsBalance}
-							totalEarnedInterest={totalEarnedInterest}
-							interestToBeCollected={interestToBeCollected}
-						/>
-					) : (
-						<NoDataRow className="col-span-1 sm:col-span-3 text-center justify-self-center">
-							{t("dashboard.no_savings_yet")}
-						</NoDataRow>
-					)}
-				</div>
+			<LinkTitle href="/savings">{t("dashboard.my_savings")}</LinkTitle>
+
+			{/* Desktop table */}
+			<div className="hidden sm:grid w-full grid-cols-[auto_1fr_1fr_1fr] grid-rows-[auto_auto] gap-y-1">
+				<span className="w-11 pr-3" />
+				<HeaderCell>{t("dashboard.current_investment")}</HeaderCell>
+				<HeaderCell>{t("dashboard.total_earned")}</HeaderCell>
+				<HeaderCell>{t("dashboard.interest_to_be_collected")}</HeaderCell>
+				{hasData ? (
+					<>
+						<div className="pr-3 flex items-center">
+							<TokenLogo currency={TOKEN_SYMBOL} size={8} />
+						</div>
+						<span className="flex items-center text-text-primary text-base font-extrabold">{balanceFmt}</span>
+						<span className="flex items-center text-text-primary text-base font-medium">{earnedFmt}</span>
+						<span className="flex items-center text-text-primary text-base font-medium">{interestFmt}</span>
+					</>
+				) : (
+					<NoDataRow className="col-span-3">{t("dashboard.no_savings_yet")}</NoDataRow>
+				)}
 			</div>
-			{savingsData && (
-				<div className="w-full flex-1 pt-10 flex items-end gap-4">
+
+			{/* Mobile stacked rows */}
+			<div className="sm:hidden w-full flex flex-col gap-3">
+				{hasData ? (
+					<>
+						<div className="w-full flex flex-row justify-between items-center gap-2">
+							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem]">
+								{t("dashboard.current_investment")}
+							</span>
+							<div className="flex flex-row items-center gap-1.5 shrink-0">
+								<TokenLogo currency={TOKEN_SYMBOL} size={5} />
+								<span className="text-text-primary text-base font-extrabold leading-tight">{balanceFmt}</span>
+							</div>
+						</div>
+						<div className="w-full flex flex-row justify-between items-center gap-2">
+							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem]">{t("dashboard.total_earned")}</span>
+							<span className="text-text-primary text-base font-medium leading-tight">{earnedFmt}</span>
+						</div>
+						<div className="w-full flex flex-row justify-between items-center gap-2">
+							<span className="text-text-muted2 text-xs font-medium leading-[1.125rem] min-w-0 flex-1">
+								{t("dashboard.interest_to_be_collected")}
+							</span>
+							<span className="text-text-primary text-base font-medium leading-tight shrink-0">{interestFmt}</span>
+						</div>
+					</>
+				) : (
+					<div className="w-full py-[1.125rem] flex items-center justify-center">
+						<span className="text-text-muted2 text-base font-[350] leading-tight">{t("dashboard.no_savings_yet")}</span>
+					</div>
+				)}
+			</div>
+
+			{hasData && (
+				<div className="w-full flex-1 pt-10 flex flex-col sm:flex-row items-stretch sm:items-end gap-4">
 					<Button
 						className="w-full h-10"
 						disabled={interestToBeCollected === 0n}

--- a/components/PageDashboard/MySavings.tsx
+++ b/components/PageDashboard/MySavings.tsx
@@ -47,11 +47,11 @@ export const MySavings = () => {
 		<div className="w-full h-full p-4 sm:p-8 flex flex-col items-start">
 			<LinkTitle href={"/savings"}>{t("dashboard.my_savings")}</LinkTitle>
 			<div className="w-full flex flex-row justify-between items-center">
-				<div className="w-full grid grid-cols-[auto_1fr_1fr_1fr] grid-rows-[auto_auto] gap-y-1">
-					<span className="w-11 pr-3"></span>
-					<HeaderCell>{t("dashboard.current_investment")}</HeaderCell>
-					<HeaderCell>{t("dashboard.total_earned")}</HeaderCell>
-					<HeaderCell>{t("dashboard.interest_to_be_collected")}</HeaderCell>
+				<div className="w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_1fr_1fr] grid-rows-[auto_auto] gap-y-1">
+					<span className="hidden sm:block w-11 pr-3"></span>
+					<HeaderCell className="hidden sm:block">{t("dashboard.current_investment")}</HeaderCell>
+					<HeaderCell className="hidden sm:block">{t("dashboard.total_earned")}</HeaderCell>
+					<HeaderCell className="hidden sm:block">{t("dashboard.interest_to_be_collected")}</HeaderCell>
 					{savingsData ? (
 						<SavingsRow
 							balance={userSavingsBalance}
@@ -59,7 +59,9 @@ export const MySavings = () => {
 							interestToBeCollected={interestToBeCollected}
 						/>
 					) : (
-						<NoDataRow className="col-span-3">{t("dashboard.no_savings_yet")}</NoDataRow>
+						<NoDataRow className="col-span-1 sm:col-span-3 text-center justify-self-center">
+							{t("dashboard.no_savings_yet")}
+						</NoDataRow>
 					)}
 				</div>
 			</div>

--- a/components/PageDashboard/MySavings.tsx
+++ b/components/PageDashboard/MySavings.tsx
@@ -47,11 +47,15 @@ export const MySavings = () => {
 		<div className="w-full h-full p-4 sm:p-8 flex flex-col items-start">
 			<LinkTitle href={"/savings"}>{t("dashboard.my_savings")}</LinkTitle>
 			<div className="w-full flex flex-row justify-between items-center">
-				<div className="w-full grid grid-cols-1 sm:grid-cols-[auto_1fr_1fr_1fr] grid-rows-[auto_auto] gap-y-1">
-					<span className="hidden sm:block w-11 pr-3"></span>
-					<HeaderCell className="hidden sm:block">{t("dashboard.current_investment")}</HeaderCell>
-					<HeaderCell className="hidden sm:block">{t("dashboard.total_earned")}</HeaderCell>
-					<HeaderCell className="hidden sm:block">{t("dashboard.interest_to_be_collected")}</HeaderCell>
+				<div
+					className={`w-full grid grid-rows-[auto_auto] gap-y-1 ${
+						savingsData ? "grid-cols-[auto_1fr_1fr_1fr]" : "grid-cols-1 sm:grid-cols-[auto_1fr_1fr_1fr]"
+					}`}
+				>
+					<span className={`${savingsData ? "w-11 pr-3" : "hidden sm:block w-11 pr-3"}`}></span>
+					<HeaderCell className={savingsData ? "" : "hidden sm:block"}>{t("dashboard.current_investment")}</HeaderCell>
+					<HeaderCell className={savingsData ? "" : "hidden sm:block"}>{t("dashboard.total_earned")}</HeaderCell>
+					<HeaderCell className={savingsData ? "" : "hidden sm:block"}>{t("dashboard.interest_to_be_collected")}</HeaderCell>
 					{savingsData ? (
 						<SavingsRow
 							balance={userSavingsBalance}

--- a/components/PageDashboard/SavingsOverview.tsx
+++ b/components/PageDashboard/SavingsOverview.tsx
@@ -12,9 +12,9 @@ import { useContractUrl, useExplorerChain } from "@hooks";
 
 const StatsBox = ({ title, value, isLast }: { title: string; value?: string | React.ReactNode; isLast?: boolean }) => {
 	return (
-		<div className={`2md:p-8 p-5 flex flex-col 2md:gap-2 gap-1 flex-1 ${!isLast ? "border-r border-borders-dividerLight" : ""}`}>
-			<span className="text-base font-[350] leading-tight">{title}</span>
-			<span className="text-lg font-[900]">{value}</span>
+		<div className={`2md:p-8 p-4 sm:p-5 flex flex-col gap-1 2md:gap-2 flex-1 ${!isLast ? "border-r border-borders-dividerLight" : ""}`}>
+			<span className="text-xs sm:text-base font-[350] leading-tight text-text-muted2">{title}</span>
+			<span className="text-base sm:text-lg font-[900]">{value}</span>
 		</div>
 	);
 };
@@ -37,7 +37,7 @@ const SavingsOverview = () => {
 
 	return (
 		<div className="w-full bg-white self-stretch rounded-xl justify-start items-center inline-flex shadow-card">
-			<div className="w-full flex md:flex-row flex-col">
+			<div className="w-full flex md:flex-row flex-col divide-y divide-borders-dividerLight md:divide-y-0">
 				<div className="w-full flex-row justify-start items-start flex overflow-hidden">
 					<StatsBox title={t("dashboard.interest_rate_apr")} value={rate !== undefined ? `${rate / 10_000}%` : "-"} />
 					<StatsBox

--- a/components/PageMonitoring/MonitoringRow.tsx
+++ b/components/PageMonitoring/MonitoringRow.tsx
@@ -70,13 +70,14 @@ export default function MonitoringRow({ headers, position, tab }: Props) {
 			}
 			tab={tab}
 			showFirstHeader={true}
+			mobileFirstColumnSplit={true}
 		>
 			{/* Collateral */}
 			<div className="flex flex-col">
 				{/* desktop view */}
 				<div className="max-md:hidden flex flex-row items-center">
 					<span className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={8} />
 					</span>
 					<span className={`col-span-2 text-md font-extrabold text-text-primary`}>{`${formatCurrency(
 						collateralBalanceNumber,
@@ -85,16 +86,15 @@ export default function MonitoringRow({ headers, position, tab }: Props) {
 					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
 
-				{/* mobile view */}
-				<div className="md:hidden flex flex-row items-center py-1 mb-3">
-					<div className="mr-4 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
-					</div>
-					<div className={`col-span-2 text-md text-text-primary font-semibold`}>{`${formatCurrency(
+				<div className="md:hidden flex flex-row items-center justify-end gap-1.5">
+					<span className="shrink-0 cursor-pointer" onClick={openExplorer}>
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={5} />
+					</span>
+					<span className="text-md text-text-primary font-semibold">{`${formatCurrency(
 						collateralBalanceNumber,
 						3,
 						3
-					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</div>
+					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
 			</div>
 

--- a/components/PageMypositions/MyPositionsBidsRow.tsx
+++ b/components/PageMypositions/MyPositionsBidsRow.tsx
@@ -52,29 +52,29 @@ export default function MyPositionsBidsRow({ headers, bid, tab }: Props) {
 			}
 			tab={tab}
 			showFirstHeader
+			mobileFirstColumnSplit
 		>
 			{/* Collateral */}
-			<div className="flex flex-col max-md:mb-5">
-				{/* desktop view */}
+			<div className="flex flex-col">
+				{/* desktop */}
 				<div className="max-md:hidden flex flex-row items-center">
 					<span className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={8} />
 					</span>
-					<span className={`col-span-2 text-md font-extrabold`}>{`${formatCurrency(
+					<span className="text-md font-extrabold">{`${formatCurrency(
 						formatUnits(bid.filledSize, position.collateralDecimals),
 						...filledSizeFractionDigits
 					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
-
-				{/* mobile view */}
-				<div className="md:hidden flex flex-row items-center">
-					<div className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
-					</div>
-					<div className={`col-span-2 text-md  font-semibold`}>{`${formatCurrency(
+				{/* mobile — inline with label via mobileFirstColumnSplit */}
+				<div className="md:hidden flex flex-row items-center justify-end gap-1.5">
+					<span className="shrink-0 cursor-pointer" onClick={openExplorer}>
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={5} />
+					</span>
+					<span className="text-md font-semibold">{`${formatCurrency(
 						formatUnits(bid.filledSize, position.collateralDecimals),
 						...filledSizeFractionDigits
-					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</div>
+					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
 			</div>
 

--- a/components/PageMypositions/MyPositionsChallengesRow.tsx
+++ b/components/PageMypositions/MyPositionsChallengesRow.tsx
@@ -71,29 +71,29 @@ export default function MyPositionsChallengesRow({ headers, challenge, tab }: Pr
 			actionCol={<MyPositionsChallengesCancel challenge={challenge} hidden={stateIdx == 1} />}
 			tab={tab}
 			showFirstHeader
+			mobileFirstColumnSplit
 		>
 			{/* Collateral */}
-			<div className="flex flex-col max-md:mb-5">
-				{/* desktop view */}
+			<div className="flex flex-col">
+				{/* desktop */}
 				<div className="max-md:hidden flex flex-row items-center">
 					<span className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={8} />
 					</span>
-					<span className={`col-span-2 text-md font-extrabold`}>{`${formatCurrency(
+					<span className="text-md font-extrabold">{`${formatCurrency(
 						challengeRemainingSize,
 						...remainingFractionDigits
 					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
-
-				{/* mobile view */}
-				<div className="md:hidden flex flex-row items-center">
-					<div className="mr-3 cursor-pointer" onClick={openExplorer}>
-						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} />
-					</div>
-					<div className={`col-span-2 text-md  font-semibold`}>{`${formatCurrency(
+				{/* mobile — inline with label via mobileFirstColumnSplit */}
+				<div className="md:hidden flex flex-row items-center justify-end gap-1.5">
+					<span className="shrink-0 cursor-pointer" onClick={openExplorer}>
+						<TokenLogo currency={normalizeTokenSymbol(position.collateralSymbol)} size={5} />
+					</span>
+					<span className="text-md font-semibold">{`${formatCurrency(
 						challengeRemainingSize,
 						...remainingFractionDigits
-					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</div>
+					)} ${normalizeTokenSymbol(position.collateralSymbol)}`}</span>
 				</div>
 			</div>
 

--- a/components/PageSavings/SavingsLeaderboardTable.tsx
+++ b/components/PageSavings/SavingsLeaderboardTable.tsx
@@ -42,9 +42,12 @@ const Rank = ({ rank }: { rank: number }) => {
 function SavingsLeaderboardRow({ headers, item, tab, rank }: Props) {
 	return (
 		<>
-			<TableRow headers={headers} tab={tab}>
+			<TableRow headers={headers} tab={tab} hideFirstOnMobile>
 				<Rank rank={rank} />
-				<div className="flex flex-col text-left">
+				<div className="flex items-center gap-2 text-left">
+					<span className="md:hidden shrink-0">
+						<Rank rank={rank} />
+					</span>
 					<AddressLabelSimple address={item.account} showLink />
 				</div>
 				<div className={`flex flex-col`}>

--- a/components/SectionTitle.tsx
+++ b/components/SectionTitle.tsx
@@ -21,10 +21,7 @@ export const SectionTitle = ({
 				>
 					<FontAwesomeIcon icon={faChevronLeft} className="w-5 h-5" />
 				</button>
-				<div
-					id={id}
-					className={`${className} mb-1 text-[1.75rem] sm:mb-5 sm:text-[1.625rem] font-black leading-[1.625rem] tracking-tight`}
-				>
+				<div id={id} className={`${className} mb-1 sm:mb-5 text-2xl sm:text-4xl font-black !leading-none tracking-tight`}>
 					{children}
 				</div>
 			</div>
@@ -32,7 +29,7 @@ export const SectionTitle = ({
 	}
 
 	return (
-		<div id={id} className={`${className} mb-1 text-[1.75rem] sm:mb-5 sm:text-[1.625rem] font-black leading-[1.625rem] tracking-tight`}>
+		<div id={id} className={`${className} mb-1 sm:mb-5 text-2xl sm:text-4xl font-black !leading-none tracking-tight`}>
 			{children}
 		</div>
 	);

--- a/components/Table/TableRow.tsx
+++ b/components/Table/TableRow.tsx
@@ -11,6 +11,7 @@ interface Props {
 	subHeaders?: string[];
 	tab: string;
 	showFirstHeader?: boolean;
+	mobileFirstColumnSplit?: boolean;
 }
 
 export default function TableRow({
@@ -24,6 +25,7 @@ export default function TableRow({
 	classNameMobile = "",
 	tab,
 	showFirstHeader = false,
+	mobileFirstColumnSplit = false,
 }: Props) {
 	return (
 		<div
@@ -47,6 +49,7 @@ export default function TableRow({
 					className={classNameMobile}
 					tab={tab}
 					showFirstHeader={showFirstHeader}
+					mobileFirstColumnSplit={mobileFirstColumnSplit}
 				>
 					{children}
 				</TableRowMobile>
@@ -65,9 +68,18 @@ interface TableRowMobileProps {
 	className: string;
 	tab: string;
 	showFirstHeader?: boolean;
+	mobileFirstColumnSplit?: boolean;
 }
 
-function TableRowMobile({ children, headers, subHeaders, className, tab, showFirstHeader = false }: TableRowMobileProps) {
+function TableRowMobile({
+	children,
+	headers,
+	subHeaders,
+	className,
+	tab,
+	showFirstHeader = false,
+	mobileFirstColumnSplit = false,
+}: TableRowMobileProps) {
 	if (headers.length === 0) {
 		return <div className={`${className} md:hidden justify-items-center text-center gap-6 grid flex-grow grid-cols-1`}>{children}</div>;
 	} else {
@@ -75,34 +87,59 @@ function TableRowMobile({ children, headers, subHeaders, className, tab, showFir
 			<div className={`${className} md:hidden grid-cols-1 flex-1`}>
 				{children.map((c, idx) => (
 					<div className="mt-1.5 flex" key={headers[idx] + idx}>
-						<div className="flex-1 text-left">
-							{idx === 0 ? (
-								<>
-									{showFirstHeader && (
-										<div className={`mb-2 ${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
-											{headers[idx]}
-										</div>
-									)}
-									<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>{c}</div>
-								</>
-							) : subHeaders.length === 0 ? (
-								<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
-									{headers[idx]}
-								</div>
-							) : (
-								<div>
+						{idx === 0 && mobileFirstColumnSplit && showFirstHeader ? (
+							<>
+								<div className="flex-1 text-left">
 									<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
 										{headers[idx]}
 									</div>
-									<div className={`${headers[idx] == tab ? "text-text-subheader font-bold" : "text-text-muted"}`}>
-										{subHeaders[idx]}
-									</div>
 								</div>
-							)}
-						</div>
-						<div className={`${headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"} text-right`}>
-							{idx === 0 ? "" : c}
-						</div>
+								<div
+									className={`${
+										headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"
+									} text-right flex min-w-0 items-center justify-end`}
+								>
+									{c}
+								</div>
+							</>
+						) : (
+							<>
+								<div className="flex-1 text-left">
+									{idx === 0 ? (
+										<>
+											{showFirstHeader && (
+												<div
+													className={`mb-2 ${
+														headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"
+													}`}
+												>
+													{headers[idx]}
+												</div>
+											)}
+											<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
+												{c}
+											</div>
+										</>
+									) : subHeaders.length === 0 ? (
+										<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
+											{headers[idx]}
+										</div>
+									) : (
+										<div>
+											<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
+												{headers[idx]}
+											</div>
+											<div className={`${headers[idx] == tab ? "text-text-subheader font-bold" : "text-text-muted"}`}>
+												{subHeaders[idx]}
+											</div>
+										</div>
+									)}
+								</div>
+								<div className={`${headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"} text-right`}>
+									{idx === 0 ? "" : c}
+								</div>
+							</>
+						)}
 					</div>
 				))}
 			</div>

--- a/components/Table/TableRow.tsx
+++ b/components/Table/TableRow.tsx
@@ -12,6 +12,7 @@ interface Props {
 	tab: string;
 	showFirstHeader?: boolean;
 	mobileFirstColumnSplit?: boolean;
+	hideFirstOnMobile?: boolean;
 }
 
 export default function TableRow({
@@ -26,6 +27,7 @@ export default function TableRow({
 	tab,
 	showFirstHeader = false,
 	mobileFirstColumnSplit = false,
+	hideFirstOnMobile = false,
 }: Props) {
 	return (
 		<div
@@ -50,6 +52,7 @@ export default function TableRow({
 					tab={tab}
 					showFirstHeader={showFirstHeader}
 					mobileFirstColumnSplit={mobileFirstColumnSplit}
+					hideFirstOnMobile={hideFirstOnMobile}
 				>
 					{children}
 				</TableRowMobile>
@@ -69,6 +72,7 @@ interface TableRowMobileProps {
 	tab: string;
 	showFirstHeader?: boolean;
 	mobileFirstColumnSplit?: boolean;
+	hideFirstOnMobile?: boolean;
 }
 
 function TableRowMobile({
@@ -79,69 +83,85 @@ function TableRowMobile({
 	tab,
 	showFirstHeader = false,
 	mobileFirstColumnSplit = false,
+	hideFirstOnMobile = false,
 }: TableRowMobileProps) {
 	if (headers.length === 0) {
 		return <div className={`${className} md:hidden justify-items-center text-center gap-6 grid flex-grow grid-cols-1`}>{children}</div>;
 	} else {
 		return (
 			<div className={`${className} md:hidden grid-cols-1 flex-1`}>
-				{children.map((c, idx) => (
-					<div className="mt-1.5 flex" key={headers[idx] + idx}>
-						{idx === 0 && mobileFirstColumnSplit && showFirstHeader ? (
-							<>
-								<div className="flex-1 text-left">
-									<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
-										{headers[idx]}
-									</div>
-								</div>
-								<div
-									className={`${
-										headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"
-									} text-right flex min-w-0 items-center justify-end`}
-								>
-									{c}
-								</div>
-							</>
-						) : (
-							<>
-								<div className="flex-1 text-left">
-									{idx === 0 ? (
-										<>
-											{showFirstHeader && (
-												<div
-													className={`mb-2 ${
-														headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"
-													}`}
-												>
-													{headers[idx]}
-												</div>
-											)}
-											<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
-												{c}
-											</div>
-										</>
-									) : subHeaders.length === 0 ? (
+				{children.map((c, idx) => {
+					if (idx === 0 && hideFirstOnMobile) return null;
+					return (
+						<div className="mt-1.5 flex" key={headers[idx] + idx}>
+							{idx === 0 && mobileFirstColumnSplit && showFirstHeader ? (
+								<>
+									<div className="flex-1 text-left">
 										<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
 											{headers[idx]}
 										</div>
-									) : (
-										<div>
+									</div>
+									<div
+										className={`${
+											headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"
+										} text-right flex min-w-0 items-center justify-end`}
+									>
+										{c}
+									</div>
+								</>
+							) : (
+								<>
+									<div className="flex-1 text-left">
+										{idx === 0 ? (
+											<>
+												{showFirstHeader && (
+													<div
+														className={`mb-2 ${
+															headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"
+														}`}
+													>
+														{headers[idx]}
+													</div>
+												)}
+												<div
+													className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}
+												>
+													{c}
+												</div>
+											</>
+										) : subHeaders.length === 0 ? (
 											<div className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}>
 												{headers[idx]}
 											</div>
-											<div className={`${headers[idx] == tab ? "text-text-subheader font-bold" : "text-text-muted"}`}>
-												{subHeaders[idx]}
+										) : (
+											<div>
+												<div
+													className={`${headers[idx] == tab ? "text-text-primary font-bold" : "text-text-muted"}`}
+												>
+													{headers[idx]}
+												</div>
+												<div
+													className={`${
+														headers[idx] == tab ? "text-text-subheader font-bold" : "text-text-muted"
+													}`}
+												>
+													{subHeaders[idx]}
+												</div>
 											</div>
-										</div>
-									)}
-								</div>
-								<div className={`${headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"} text-right`}>
-									{idx === 0 ? "" : c}
-								</div>
-							</>
-						)}
-					</div>
-				))}
+										)}
+									</div>
+									<div
+										className={`${
+											headers[idx] == tab ? "!text-text-primary !font-bold" : "!text-text-muted"
+										} text-right`}
+									>
+										{idx === 0 ? "" : c}
+									</div>
+								</>
+							)}
+						</div>
+					);
+				})}
 			</div>
 		);
 	}


### PR DESCRIPTION
## Summary
Improves dashboard and savings UI on small screens: consistent `TableRow` split layout, better empty-state centering, and fixes for My Borrow / My Savings tables. Updates `SectionTitle` typography and savings leaderboard rank display. Touches dashboard, monitoring, challenges, my positions, and savings tables.

## Test plan
- [ ] Spot-check dashboard My Borrow / My Savings / equity on mobile width
- [ ] Confirm savings leaderboard rank and tables render correctly
- [ ] Quick pass on challenges / monitoring / my positions rows if those flows are in scope

<img width="417" height="444" alt="image" src="https://github.com/user-attachments/assets/194c0f24-3ccb-43dd-9091-31c4cfc45d65" />

<img width="539" height="281" alt="image" src="https://github.com/user-attachments/assets/253f230a-e014-4998-aaf7-e56d9f353edd" />
