### PR TITLE
Use shared public-view address helper in My Positions tables

### DIFF
--- a/components/PageMypositions/MyPositionsBidsTable.tsx
+++ b/components/PageMypositions/MyPositionsBidsTable.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "next-i18next";
 import { useExpandableTable } from "@hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { getPublicViewAddress } from "../../utils/url";
 
 export default function MyPositionsBidsTable() {
 	const { t } = useTranslation();
@@ -32,7 +33,7 @@ export default function MyPositionsBidsTable() {
 	const positions = useSelector((state: RootState) => state.positions.mapping?.map || {});
 
 	const router = useRouter();
-	const overwrite = router.query.address as Address;
+	const overwrite = getPublicViewAddress(router);
 
 	const { address } = useAccount();
 	const account = overwrite || address || zeroAddress;

--- a/components/PageMypositions/MyPositionsChallengesTable.tsx
+++ b/components/PageMypositions/MyPositionsChallengesTable.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "next-i18next";
 import { useExpandableTable } from "@hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { getPublicViewAddress } from "../../utils/url";
 
 export default function MyPositionsChallengesTable() {
 	const { t } = useTranslation();
@@ -40,7 +41,7 @@ export default function MyPositionsChallengesTable() {
 	const auction = useSelector((state: RootState) => state.challenges.challengesPrices?.map || {});
 
 	const router = useRouter();
-	const overwrite = router.query.address as Address;
+	const overwrite = getPublicViewAddress(router);
 
 	const { address } = useAccount();
 	const account = overwrite || address || zeroAddress;

--- a/components/PageMypositions/MypositionsTable.tsx
+++ b/components/PageMypositions/MypositionsTable.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "next-i18next";
 import { useExpandableTable } from "@hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { getPublicViewAddress } from "../../utils/url";
 
 export default function MypositionsTable() {
 	const { t } = useTranslation();
@@ -38,7 +39,7 @@ export default function MypositionsTable() {
 	const prices = useSelector((state: RootState) => state.prices.coingecko || {});
 
 	const router = useRouter();
-	const overwrite = router.query.address as Address;
+	const overwrite = getPublicViewAddress(router);
 
 	const { address } = useAccount();
 	const account = overwrite || address || zeroAddress;


### PR DESCRIPTION
## Summary
- Replace direct `router.query.address` casts with `getPublicViewAddress(router)` in all My Positions tables.
- Keep address override behavior consistent across positions, challenges, and bids views.

## Test plan
- [ ] Open dashboard My Positions page without `address` query param and confirm current wallet data renders.
- [ ] Open dashboard with `?address=<valid-address>` and confirm all three tables use the override account.
- [ ] Confirm no TypeScript or runtime errors in these views.