### PR TITLE
Fix incorrect Total Income on equity page

### DIFF
--- a/components/PageEquity/EquityNativePoolShareDetailsCard.tsx
+++ b/components/PageEquity/EquityNativePoolShareDetailsCard.tsx
@@ -201,9 +201,8 @@ export default function EquityNativePoolShareDetailsCard() {
 					<div className="text-sm font-medium leading-relaxed">{t("equity.total_income")}</div>
 					<div className="text-sm font-medium leading-tight ">
 						{typeof profit === "number" && typeof unrealizedProfit === "number" && typeof loss === "number"
-							? formatCurrency(profit + unrealizedProfit - loss + 300000, 2, 2) + ` ${TOKEN_SYMBOL}`
+							? formatCurrency(profit + unrealizedProfit - loss, 2, 2) + ` ${TOKEN_SYMBOL}`
 							: "-"}{" "}
-						{/* 300k was sent directly to Equity contract */}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Remove hardcoded +300k JUSD offset from Total Income calculation on the equity page
- The offset was inflating the displayed value incorrectly

## Test plan
- [ ] Verify Total Income on /equity shows `profit + unrealizedProfit - loss` without the 300k offset