### PR TITLE
Use citreascan.com RPC endpoints in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ env:
     NEXT_PUBLIC_PONDER_URL_TESTNET: https://dev.ponder.testnet.juicedollar.com
     NEXT_PUBLIC_PONDER_URL_MAINNET: https://dev.ponder.juicedollar.com
     NEXT_PUBLIC_CHAIN_NAME: testnet
-    NEXT_PUBLIC_RPC_URL_MAINNET: https://rpc.testnet.juiceswap.com/
-    NEXT_PUBLIC_RPC_URL_TESTNET: https://rpc.testnet.juiceswap.com/
+    NEXT_PUBLIC_RPC_URL_MAINNET: https://rpc.citreascan.com/
+    NEXT_PUBLIC_RPC_URL_TESTNET: https://rpc.testnet.citreascan.com/
 
 jobs:
     test:


### PR DESCRIPTION
## Summary
- Switch CI RPC URLs from `rpc.testnet.juiceswap.com` to `rpc.citreascan.com` / `rpc.testnet.citreascan.com`
- JuiceDollar uses CitreaScan RPC, not JuiceSwap

## Test plan
- [ ] CI passes (lint + build)