### PR TITLE
feat: hide blacklisted positions from auctions list

### DIFF
--- a/components/PageChallenges/ChallengesTable.tsx
+++ b/components/PageChallenges/ChallengesTable.tsx
@@ -21,6 +21,7 @@ import { useExpandableTable } from "@hooks";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import Link from "next/link";
+import { BLACKLISTED_AUCTION_POSITIONS } from "@utils";
 
 export default function ChallengesTable() {
 	const { t } = useTranslation();
@@ -33,10 +34,12 @@ export default function ChallengesTable() {
 	const prices = useSelector((state: RootState) => state.prices.coingecko || {});
 	const auction = useSelector((state: RootState) => state.challenges.challengesPrices?.map || {});
 
+	const blacklist = new Set(BLACKLISTED_AUCTION_POSITIONS.map((p) => p.toLowerCase()));
 	const matchingChallenges = (challenges || []).filter((c) => {
 		// DEV: For displaying "Inactive" challenges
 		// const DIFFINMS: number = 1000 * 60 * 60 * 24 * 3; // show e.g. last 10days
 		// const matching: boolean = Date.now() - parseInt(c.start.toString()) * 1000 < DIFFINMS;
+		if (blacklist.has(c.position.toLowerCase())) return false;
 		return c.status == "Active";
 	});
 

--- a/pages/monitoring/[address]/index.tsx
+++ b/pages/monitoring/[address]/index.tsx
@@ -12,6 +12,7 @@ import {
 	TOKEN_SYMBOL,
 	toQueryString,
 	normalizeTokenSymbol,
+	BLACKLISTED_AUCTION_POSITIONS,
 } from "@utils";
 import { Address, formatUnits, zeroAddress } from "viem";
 import { useContractUrl, useExplorerChain } from "@hooks";
@@ -43,7 +44,10 @@ export default function PositionDetail() {
 	const challengesPositions = useSelector((state: RootState) => state.challenges.positions);
 
 	const position = positions.find((p) => p.position.toLowerCase() === address.toLowerCase());
-	const challengesActive = (challengesPositions?.map[address.toLowerCase() as Address] || []).filter((c) => c.status === "Active");
+	const isBlacklisted = BLACKLISTED_AUCTION_POSITIONS.some((p) => p.toLowerCase() === address.toLowerCase());
+	const challengesActive = isBlacklisted
+		? []
+		: (challengesPositions?.map[address.toLowerCase() as Address] || []).filter((c) => c.status === "Active");
 	const chain = useExplorerChain();
 	const explorerUrl = useContractUrl(String(address), chain);
 	const ownerLink = useContractUrl(position?.owner || zeroAddress, chain);

--- a/utils/constant.ts
+++ b/utils/constant.ts
@@ -43,6 +43,8 @@ export const WHITELISTED_POSITIONS: `0x${string}`[] = [];
 
 export const INTERNAL_PROTOCOL_POSITIONS: `0x${string}`[] = [];
 
+export const BLACKLISTED_AUCTION_POSITIONS: `0x${string}`[] = ["0x77f184feFB9d66fd0c02AD77eFd26991Abe129f0"];
+
 export const NATIVE_WRAPPED_SYMBOLS = ["wcbtc"];
 export const NATIVE_GAS_BUFFER = 10_000_000_000_000n; // 0.00001 cBTC reserved for gas fees
 export const DUST_JUSD = BigInt(2e16);


### PR DESCRIPTION
## Summary
- Add `BLACKLISTED_AUCTION_POSITIONS` in `utils/constant.ts` and seed with `0x77f184feFB9d66fd0c02AD77eFd26991Abe129f0`
- Filter blacklisted positions out of `ChallengesTable` so their auctions are no longer shown on `/challenges` or the dashboard tab
- Position pages (`/monitoring/[address]`) remain accessible by direct URL — only the auctions listing is filtered

## Test plan
- [ ] `/challenges` no longer shows the auction for `0x77f1…29f0`
- [ ] Dashboard "Auctions" tab no longer shows it
- [ ] Direct URL `/monitoring/0x77f184feFB9d66fd0c02AD77eFd26991Abe129f0` still loads the position
- [ ] Other auctions render normally