### PR TITLE
Show notice on Savings page when rate is 0%

### DIFF
--- a/components/PageSavings/SavingsInteractionSection.tsx
+++ b/components/PageSavings/SavingsInteractionSection.tsx
@@ -377,6 +377,12 @@ export default function SavingsInteractionSection() {
 					<span className="font-extrabold">{rate !== undefined ? `${rate / 10_000}%` : "-"}</span>
 				</div>
 			</div>
+			{rate === 0 && (
+				<div className="w-full rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
+					<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
+					<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
+				</div>
+			)}
 			<div className="flex flex-col gap-y-3">
 				<div className="pb-1 flex flex-row justify-start items-center border-b border-b-borders-dividerLight">
 					<span className="text-text-disabled font-medium text-base leading-tight">{t("savings.current_invest")}</span>

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -765,6 +765,10 @@
 			"withdraw": "Auszahlen:",
 			"withdrawing": "Auszahlung von Ersparnissen wird durchgeführt...",
 			"successfully_withdrawn": "Erfolgreich ausgezahlt"
+		},
+		"zero_rate_notice": {
+			"title": "Warum ist die Rate aktuell 0%?",
+			"body": "Im Protokoll gibt es derzeit keine aktiven Kreditpositionen, daher fließen keine Zinsen an die Savings-Einleger. Das Protokoll ist vollständig dezentralisiert — jeder Teilnehmer kann eine Kreditposition eröffnen und einen Governance-Vorschlag einreichen, um die Savings-Rate wieder zu erhöhen."
 		}
 	},
 	"coverage": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -770,6 +770,10 @@
 			"withdraw": "Withdraw:",
 			"withdrawing": "Withdrawing from savings...",
 			"successfully_withdrawn": "Successfully withdrawn"
+		},
+		"zero_rate_notice": {
+			"title": "Why is the rate currently 0%?",
+			"body": "There are no active loan positions in the protocol right now, so no interest is flowing to Savings depositors. The protocol is fully decentralized — any participant can open a loan position and submit a governance proposal to raise the savings rate again."
 		}
 	},
 	"coverage": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -765,6 +765,10 @@
 			"withdraw": "Retirar:",
 			"withdrawing": "Retirando de ahorros...",
 			"successfully_withdrawn": "Retiro exitoso"
+		},
+		"zero_rate_notice": {
+			"title": "¿Por qué la tasa es actualmente del 0%?",
+			"body": "Actualmente no hay posiciones de préstamo activas en el protocolo, por lo que no se está pagando ningún interés a los depositantes de Savings. El protocolo está totalmente descentralizado — cualquier participante puede abrir una posición de préstamo y enviar una propuesta de gobernanza para aumentar de nuevo la tasa de Savings."
 		}
 	},
 	"coverage": {

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -765,6 +765,10 @@
 			"withdraw": "Retirer :",
 			"withdrawing": "Retrait de l'épargne en cours…",
 			"successfully_withdrawn": "Retrait effectué avec succès"
+		},
+		"zero_rate_notice": {
+			"title": "Pourquoi le taux est-il actuellement de 0 % ?",
+			"body": "Il n'y a actuellement aucune position de prêt active dans le protocole, donc aucun intérêt n'est versé aux déposants Savings. Le protocole est entièrement décentralisé — tout participant peut ouvrir une position de prêt et soumettre une proposition de gouvernance pour augmenter à nouveau le taux Savings."
 		}
 	},
 	"coverage": {

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -772,6 +772,10 @@
 			"withdraw": "Preleva:",
 			"withdrawing": "Prelievo dai risparmi...",
 			"successfully_withdrawn": "Prelievo completato con successo"
+		},
+		"zero_rate_notice": {
+			"title": "Perché il tasso è attualmente dello 0%?",
+			"body": "Al momento non ci sono posizioni di prestito attive nel protocollo, quindi non viene erogato alcun interesse ai depositanti Savings. Il protocollo è completamente decentralizzato — qualsiasi partecipante può aprire una posizione di prestito e presentare una proposta di governance per aumentare nuovamente il tasso Savings."
 		}
 	},
 	"coverage": {


### PR DESCRIPTION
## Summary
- The Savings page already shows the on-chain rate dynamically, so when V2 is disabled (today) and V3 reaches 0% (after applyChange on 2026-05-16) it displays `0%` with no context.
- Adds a conditional banner under the rate badge that appears only when `rate === 0`, explaining that no active loan positions are paying interest and that any participant can open a position or submit a governance proposal to raise the rate again.
- Auto-hides once governance sets a non-zero rate — no follow-up cleanup needed.

## Changes
- `components/PageSavings/SavingsInteractionSection.tsx` — conditional banner block under the existing APR badge
- `public/locales/{en,de,fr,it,es}/common.json` — new `savings.zero_rate_notice.{title,body}` keys (5 locales)

## Test plan
- [ ] Connect to Citrea mainnet on the dev/preview deploy
- [ ] Open `/savings` while V2/V3 rate is `0` → banner visible under the APR badge
- [ ] Switch language (DE/FR/IT/ES) → translated copy renders
- [ ] After governance raises the rate to a non-zero value, banner disappears automatically