### PR TITLE
Extend 0%-rate handling to dashboard, rates page, and deposit button

### DIFF
--- a/components/PageDashboard/MyInvestmentSection.tsx
+++ b/components/PageDashboard/MyInvestmentSection.tsx
@@ -4,6 +4,8 @@ import Button from "@components/Button";
 import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslation } from "next-i18next";
+import { useSelector } from "react-redux";
+import { RootState } from "../../redux/redux.store";
 
 const ExplanationItem = ({ icon, title, description }: { icon: string; title: string; description: string }) => (
 	<div className="max-w-[28rem] justify-start items-start gap-3 flex">
@@ -19,6 +21,7 @@ const ExplanationItem = ({ icon, title, description }: { icon: string; title: st
 
 export const MyInvestmentSection = () => {
 	const { t } = useTranslation();
+	const rate = useSelector((state: RootState) => state.savings.savingsInfo?.rate);
 
 	return (
 		<div className="self-stretch p-4 sm:p-8 sm:gap-10 border-b border-borders-primary flex justify-between flex-col sm:flex-row">
@@ -41,6 +44,12 @@ export const MyInvestmentSection = () => {
 					title={t("dashboard.earn_interest")}
 					description={t("dashboard.earn_interest_description")}
 				/>
+				{rate === 0 && (
+					<div className="w-full rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
+						<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
+						<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
+					</div>
+				)}
 				<ExplanationItem
 					icon="/icons/grow.svg"
 					title={t("dashboard.benefit_from_the_JUSD_protocol")}

--- a/components/PageRates/RatesSummary.tsx
+++ b/components/PageRates/RatesSummary.tsx
@@ -91,6 +91,12 @@ export default function RatesSummary() {
 							<DisplayLabel label={t("rates.estimated_interest_pa")} />
 							<DisplayAmount className="mt-1" amount={savingsInterestPA} currency={TOKEN_SYMBOL} hideLogo />
 						</AppBox>
+						{savingsRate === 0 && (
+							<div className="rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
+								<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
+								<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
+							</div>
+						)}
 					</div>
 				</AppCard>
 			</div>

--- a/components/PageSavings/SavingsInteractionSection.tsx
+++ b/components/PageSavings/SavingsInteractionSection.tsx
@@ -321,7 +321,11 @@ export default function SavingsInteractionSection() {
 			setButtonLabel(t("savings.enter_amount_to_add_savings"));
 		} else {
 			setError(null);
-			setButtonLabel(t("savings.start_earning_interest", { rate: rate !== undefined ? `${rate / 10_000}` : "-" }));
+			if (rate === 0) {
+				setButtonLabel(t("savings.deposit_to_savings"));
+			} else {
+				setButtonLabel(t("savings.start_earning_interest", { rate: rate !== undefined ? `${rate / 10_000}` : "-" }));
+			}
 		}
 	}, [amount, rate, isDeposit, userBalance, t]);
 

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -742,6 +742,7 @@
 		"current_invest": "Dein aktuelles Invest",
 		"enter_amount_to_add_savings": "Betrag zum Einzahlen eingeben",
 		"start_earning_interest": "Starte Zinsen mit {{rate}}% auf dein JUSD",
+		"deposit_to_savings": "In Savings einzahlen",
 		"enter_withdraw_amount": "Betrag zum Auszahlen eingeben",
 		"withdraw_to_my_wallet": "Auszahlen auf meine Wallet",
 		"transaction_history": "Transaktionsverlauf",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -745,6 +745,7 @@
 		"current_invest": "Your Current Invest",
 		"enter_amount_to_add_savings": "Enter amount to add savings",
 		"start_earning_interest": "Start earning {{rate}}% on your JUSD",
+		"deposit_to_savings": "Deposit to Savings",
 		"enter_withdraw_amount": "Enter withdraw amount",
 		"withdraw_to_my_wallet": "Withdraw to my wallet",
 		"transaction_history": "Transaction history",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -742,6 +742,7 @@
 		"current_invest": "Tu inversión actual",
 		"enter_amount_to_add_savings": "Ingresar cantidad para ahorrar",
 		"start_earning_interest": "Comenzar a ganar {{rate}}% en su JUSD",
+		"deposit_to_savings": "Depositar en Savings",
 		"enter_withdraw_amount": "Ingresar cantidad para retirar",
 		"withdraw_to_my_wallet": "Retirar a mi monedero",
 		"transaction_history": "Historial de transacciones",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -742,6 +742,7 @@
 		"current_invest": "Votre investissement actuel",
 		"enter_amount_to_add_savings": "Saisissez le montant à ajouter à l'épargne",
 		"start_earning_interest": "Commencer à gagner {{rate}}% sur votre JUSD",
+		"deposit_to_savings": "Déposer dans Savings",
 		"enter_withdraw_amount": "Saisissez le montant à retirer",
 		"withdraw_to_my_wallet": "Retirer vers mon portefeuille",
 		"transaction_history": "Historique des transactions",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -749,6 +749,7 @@
 		"current_invest": "Il Tuo Investimento Attuale",
 		"enter_amount_to_add_savings": "Inserisci importo per aggiungere risparmi",
 		"start_earning_interest": "Inizia a guadagnare {{rate}}% sui tuoi JUSD",
+		"deposit_to_savings": "Deposita in Savings",
 		"enter_withdraw_amount": "Inserisci importo da prelevare",
 		"withdraw_to_my_wallet": "Preleva al mio portafoglio",
 		"transaction_history": "Storico transazioni",


### PR DESCRIPTION
## Summary
Follow-up to #200. A deeper audit surfaced three more surfaces where the 0% Savings rate creates misleading UX or stat displays without context. This PR adds the same conditional handling (`rate === 0`) to them.

## Changes

**A. Savings deposit button label** — `components/PageSavings/SavingsInteractionSection.tsx`
- Previously: button read **"Start earning 0% on your JUSD"** at rate=0 (nonsensical)
- Now: neutral **"Deposit to Savings"** when rate=0; existing "Start earning X% on your JUSD" preserved for non-zero rates
- New i18n key `savings.deposit_to_savings` in all 5 locales

**B. Dashboard `MyInvestmentSection`** — `components/PageDashboard/MyInvestmentSection.tsx`
- Adds the existing `savings.zero_rate_notice` banner under the "Earn Interest" explanation row when rate=0
- The dashboard's "Earn secure, hassle-free returns" copy now has immediate context for users who land here before visiting `/savings`

**C. Rates page Savings card** — `components/PageRates/RatesSummary.tsx`
- Adds the same notice banner inside the "Savings Interest (Expenses)" card when `savingsRate === 0`
- Explains why the displayed Total Savings × 0% APR = 0 JUSD/year

All three notices auto-hide once governance sets a non-zero rate. No new copy was authored — the dashboard and rates banners reuse the `savings.zero_rate_notice.{title,body}` keys introduced in #200.

## Test plan
- [ ] `/savings` deposit button: enter amount → reads "Deposit to Savings" while rate=0
- [ ] `/dashboard`: banner visible under "Earn Interest" item while rate=0
- [ ] `/rates`: banner visible at bottom of Savings Interest card while rate=0
- [ ] All 5 locales render translated copy
- [ ] After governance raises the rate: all three banners disappear, button label reverts to "Start earning X% on your JUSD"