### PR TITLE
Force 0% savings rate display and always show notice

### DIFF
--- a/components/PageDashboard/MyInvestmentSection.tsx
+++ b/components/PageDashboard/MyInvestmentSection.tsx
@@ -4,8 +4,6 @@ import Button from "@components/Button";
 import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslation } from "next-i18next";
-import { useSelector } from "react-redux";
-import { RootState } from "../../redux/redux.store";
 
 const ExplanationItem = ({ icon, title, description }: { icon: string; title: string; description: string }) => (
 	<div className="max-w-[28rem] justify-start items-start gap-3 flex">
@@ -21,7 +19,6 @@ const ExplanationItem = ({ icon, title, description }: { icon: string; title: st
 
 export const MyInvestmentSection = () => {
 	const { t } = useTranslation();
-	const rate = useSelector((state: RootState) => state.savings.savingsInfo?.rate);
 
 	return (
 		<div className="self-stretch p-4 sm:p-8 sm:gap-10 border-b border-borders-primary flex justify-between flex-col sm:flex-row">
@@ -44,12 +41,11 @@ export const MyInvestmentSection = () => {
 					title={t("dashboard.earn_interest")}
 					description={t("dashboard.earn_interest_description")}
 				/>
-				{rate === 0 && (
-					<div className="w-full rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
-						<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
-						<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
-					</div>
-				)}
+				{/* Savings effectively inactive — show notice unconditionally until loan positions resume. */}
+				<div className="w-full rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
+					<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
+					<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
+				</div>
 				<ExplanationItem
 					icon="/icons/grow.svg"
 					title={t("dashboard.benefit_from_the_JUSD_protocol")}

--- a/components/PageDashboard/SavingsOverview.tsx
+++ b/components/PageDashboard/SavingsOverview.tsx
@@ -21,7 +21,6 @@ const StatsBox = ({ title, value, isLast }: { title: string; value?: string | Re
 
 const SavingsOverview = () => {
 	const savingsInfo = useSelector((state: RootState) => state.savings.savingsInfo);
-	const rate = savingsInfo?.rate;
 	const totalInterest = savingsInfo?.totalInterest;
 	const chainId = useChainId();
 	const chain = useExplorerChain();
@@ -46,7 +45,8 @@ const SavingsOverview = () => {
 		<div className="w-full bg-white self-stretch rounded-xl justify-start items-center inline-flex shadow-card">
 			<div className="w-full flex md:flex-row flex-col divide-y divide-borders-dividerLight md:divide-y-0">
 				<div className="w-full flex-row justify-start items-start flex overflow-hidden">
-					<StatsBox title={t("dashboard.interest_rate_apr")} value={rate !== undefined ? `${rate / 10_000}%` : "-"} />
+					{/* Savings effectively inactive — display 0% regardless of on-chain rate until loan positions resume. */}
+					<StatsBox title={t("dashboard.interest_rate_apr")} value="0%" />
 					<StatsBox
 						title={t("dashboard.total_savings")}
 						value={formatCurrency(formatUnits(totalSavings, 18), 2, 2) || undefined}

--- a/components/PageRates/RatesSummary.tsx
+++ b/components/PageRates/RatesSummary.tsx
@@ -37,7 +37,8 @@ export default function RatesSummary() {
 	const totalMinted = exposures.reduce((sum, e) => sum + e.mint.totalMinted, 0);
 	const loanInterestPA = eco.exposureData?.general?.earningsPerAnnum ?? 0;
 
-	const savingsRate = savingsInfo ? savingsInfo.rate / 10_000 : 0;
+	// Savings effectively inactive — display 0% regardless of on-chain rate until loan positions resume.
+	const savingsRate = 0;
 	const totalSavingsNum = parseFloat(formatUnits(totalSavingsRaw, 18));
 	const savingsInterestPA = (totalSavingsNum * savingsRate) / 100;
 	const netInterest = loanInterestPA - savingsInterestPA;

--- a/components/PageSavings/SavingsHistoryCard.tsx
+++ b/components/PageSavings/SavingsHistoryCard.tsx
@@ -44,7 +44,6 @@ const getStartTimestampByTimeframe = (timeframe: Timeframe) => {
 
 export default function SavingsHistoryCard() {
 	const savingsInfo = useSelector((state: RootState) => state.savings.savingsInfo);
-	const rate = savingsInfo?.rate;
 	const totalInterest = savingsInfo?.totalInterest;
 	const [timeframe, setTimeframe] = useState<Timeframe>(Timeframe.ALL);
 	const { totalSavings } = useTotalSavingsQuery();
@@ -189,7 +188,8 @@ export default function SavingsHistoryCard() {
 			<div className="flex flex-col justify-start gap-3 py-6 px-5 border-t border-borders-dividerLight border-offset-1">
 				<div className="flex flex-row justify-between">
 					<div className="text-sm font-medium leading-relaxed">{t("savings.interest_rate_apr")}</div>
-					<div className="text-sm font-medium leading-tight ">{rate !== undefined ? `${rate / 10_000}%` : "-"}</div>
+					{/* Savings effectively inactive — display 0% regardless of on-chain rate until loan positions resume. */}
+					<div className="text-sm font-medium leading-tight ">0%</div>
 				</div>
 				<div className="flex flex-row justify-between">
 					<div className="text-sm font-medium leading-relaxed">{t("savings.total_savers")}</div>

--- a/components/PageSavings/SavingsInteractionSection.tsx
+++ b/components/PageSavings/SavingsInteractionSection.tsx
@@ -321,11 +321,8 @@ export default function SavingsInteractionSection() {
 			setButtonLabel(t("savings.enter_amount_to_add_savings"));
 		} else {
 			setError(null);
-			if (rate === 0) {
-				setButtonLabel(t("savings.deposit_to_savings"));
-			} else {
-				setButtonLabel(t("savings.start_earning_interest", { rate: rate !== undefined ? `${rate / 10_000}` : "-" }));
-			}
+			// Savings effectively inactive — no active loan positions are paying interest.
+			setButtonLabel(t("savings.deposit_to_savings"));
 		}
 	}, [amount, rate, isDeposit, userBalance, t]);
 
@@ -378,15 +375,14 @@ export default function SavingsInteractionSection() {
 				<div className="text-text-title text-center text-lg sm:text-xl font-black ">{t("savings.earn_yield_on_your_d_euro")}</div>
 				<div className="py-1 px-3 rounded-lg bg-[#FDF2E2] text-[#272B38] flex flex-row items-center gap-x-2 text-sm leading-[0.875rem]">
 					<span className="font-[400]">{t("savings.savings_rate")} (APR)</span>
-					<span className="font-extrabold">{rate !== undefined ? `${rate / 10_000}%` : "-"}</span>
+					{/* Savings effectively inactive — display 0% regardless of on-chain rate until loan positions resume. */}
+					<span className="font-extrabold">0%</span>
 				</div>
 			</div>
-			{rate === 0 && (
-				<div className="w-full rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
-					<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
-					<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
-				</div>
-			)}
+			<div className="w-full rounded-lg border-l-[3px] border-[#F57F00] bg-[#FDF2E2] px-4 py-3 text-sm text-[#272B38] flex flex-col gap-y-1.5">
+				<span className="font-extrabold">{t("savings.zero_rate_notice.title")}</span>
+				<span className="font-medium leading-snug">{t("savings.zero_rate_notice.body")}</span>
+			</div>
 			<div className="flex flex-col gap-y-3">
 				<div className="pb-1 flex flex-row justify-start items-center border-b border-b-borders-dividerLight">
 					<span className="text-text-disabled font-medium text-base leading-tight">{t("savings.current_invest")}</span>


### PR DESCRIPTION
## Summary
The on-chain V3 savings rate is still 10% (V3 `applyChange()` is pending, scheduled for 2026-05-16). The previous PR (#202) showed the notice and the neutral button label only when `rate === 0`, so on the production bapp users currently see "Savings rate (APR) 10%" with no context — even though no active loan positions are paying interest.

This PR overrides the live rate displays to **0%** and shows the explanatory notice **unconditionally**, so the UI matches the actual yield users can expect right now. After V3 `applyChange` tomorrow, the override matches the on-chain rate and remains coherent.

## Changes
- `components/PageSavings/SavingsInteractionSection.tsx` — rate badge `0%`, button always uses `deposit_to_savings`, notice always rendered
- `components/PageSavings/SavingsHistoryCard.tsx` — APR row hardcoded `0%`, unused `rate` removed
- `components/PageDashboard/SavingsOverview.tsx` — StatsBox hardcoded `0%`, unused `rate` removed
- `components/PageDashboard/MyInvestmentSection.tsx` — notice rendered unconditionally
- `components/PageRates/RatesSummary.tsx` — `savingsRate` constant `0`, banner unchanged (still triggers via the constant)

Each override has an inline comment explaining the reason. **Revert this commit to restore dynamic on-chain rate display** once governance reactivates Savings with a non-zero rate.

## Test plan
- [ ] `/savings` shows "Savings rate (APR) 0%" + notice banner regardless of on-chain V3 rate
- [ ] Deposit button reads "Deposit to Savings"
- [ ] `/savings` history card APR row reads `0%`
- [ ] `/dashboard` SavingsOverview StatsBox reads `0%`; notice visible under "Earn Interest"
- [ ] `/rates` Savings Interest card shows rate `0%`, estimated interest `0 JUSD`, and notice
- [ ] All 5 locales render the notice